### PR TITLE
DBSeqHiLoGenerator constructor hard coded maxLo

### DIFF
--- a/src/main/java/com/rapiddweller/platform/db/DBSeqHiLoGenerator.java
+++ b/src/main/java/com/rapiddweller/platform/db/DBSeqHiLoGenerator.java
@@ -45,7 +45,7 @@ public class DBSeqHiLoGenerator extends HiLoGenerator {
    * @param maxLo the max lo
    */
   public DBSeqHiLoGenerator(String name, int maxLo) {
-    this(name, 100, null);
+	this(name, maxLo, null);
   }
 
   /**


### PR DESCRIPTION
root cause : DBSeqHiLoGenerator constructor DBSeqHiLoGenerator(String name, int maxLo) hard coded maxLo value as 100
solution : update constructor to update hard coded value 100 to variable maxLo