### PR TITLE
DBSystem.checkOracleDriverVersion hitting NullPointerException due to ConnectionHolder object is null

### DIFF
--- a/src/main/java/com/rapiddweller/platform/db/DBSystem.java
+++ b/src/main/java/com/rapiddweller/platform/db/DBSystem.java
@@ -75,6 +75,7 @@ import com.rapiddweller.model.data.TypeDescriptor;
 import com.rapiddweller.model.data.TypeMapper;
 import com.rapiddweller.script.PrimitiveType;
 import com.rapiddweller.script.expression.ConstantExpression;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -957,9 +958,7 @@ public abstract class DBSystem extends AbstractStorageSystem {
 
   private void checkOracleDriverVersion(String driver) {
     if (driver != null && driver.contains("oracle")) {
-      Connection connection;
-      try {
-        connection = getConnection();
+      try (Connection connection = createConnection()) {
         DatabaseMetaData metaData = connection.getMetaData();
         VersionNumber driverVersion =
             VersionNumber.valueOf(metaData.getDriverVersion());
@@ -970,8 +969,6 @@ public abstract class DBSystem extends AbstractStorageSystem {
         }
       } catch (SQLException e) {
         throw new ConfigurationError(e);
-      } finally {
-        close();
       }
     }
   }


### PR DESCRIPTION
root cause : checkOracleDriverVersion hitting NullPointerException due to ConnectionHolder object is null. When Creating new DefaultDbSystem object the ConnectionHolder will not initialized until DefaultDbSystem is construct, however checkOracleDriverVersion is invoke in the constructor of DBSystem.
Solution : Create a connection to check the oracle driver version and close it afterward, instead of using the connection holder.