### PR TITLE
postgres: support for uuid column type

### DIFF
--- a/src/main/java/com/rapiddweller/platform/db/JdbcMetaTypeMapper.java
+++ b/src/main/java/com/rapiddweller/platform/db/JdbcMetaTypeMapper.java
@@ -77,7 +77,7 @@ public class JdbcMetaTypeMapper {
         Types.TINYINT, PrimitiveType.BYTE,
         Types.VARBINARY, PrimitiveType.BINARY,
         Types.VARCHAR, PrimitiveType.STRING,
-        Types.OTHER, PrimitiveType.STRING);
+        Types.OTHER, PrimitiveType.OBJECT);
   }
 
   private JdbcMetaTypeMapper() {


### PR DESCRIPTION
This fixes the following issue when generating
data for tables containing uuid columns:

```
Caused by: org.postgresql.util.PSQLException: ERROR: column "user_uuid"
      is of type uuid but expression is of type character varying
      Hint: You will need to rewrite or cast the expression
```