### PR TITLE
(archetypes, tests) 

### DIFF
--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/annoxsd/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/annoxsd/pom.xml
@@ -44,12 +44,12 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/extend/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/extend/pom.xml
@@ -74,13 +74,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
                 </dependencies>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/fixedwidth/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/fixedwidth/pom.xml
@@ -79,13 +79,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
                 </dependencies>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/reprodb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/reprodb/pom.xml
@@ -21,8 +21,8 @@
         <dependency_jaybird.version>4.0.1.java11</dependency_jaybird.version>
         <dependency_jtds.version>1.3.1</dependency_jtds.version>
         <dependency_junit.version>4.13.1</dependency_junit.version>
-        <dependency_log4j-api.version>2.14.0</dependency_log4j-api.version>
-        <dependency_log4j-core.version>2.14.0</dependency_log4j-core.version>
+        <dependency_log4j-api.version>[2.17.0,)</dependency_log4j-api.version>
+        <dependency_log4j-core.version>[2.17.0,)</dependency_log4j-core.version>
         <dependency_mysql-connector-java.version>8.0.20</dependency_mysql-connector-java.version>
         <dependency_postgresql.version>42.2.12</dependency_postgresql.version>
         <dependency_validation-api.version>2.0.1.Final</dependency_validation-api.version>
@@ -181,13 +181,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
                 </dependencies>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/shopdb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/shopdb/pom.xml
@@ -23,8 +23,8 @@
         <dependency_jaybird.version>4.0.1.java11</dependency_jaybird.version>
         <dependency_jtds.version>1.3.1</dependency_jtds.version>
         <dependency_junit.version>4.13.1</dependency_junit.version>
-        <dependency_log4j-api.version>2.14.0</dependency_log4j-api.version>
-        <dependency_log4j-core.version>2.14.0</dependency_log4j-core.version>
+        <dependency_log4j-api.version>[2.17.0,)</dependency_log4j-api.version>
+        <dependency_log4j-core.version>[2.17.0,)</dependency_log4j-core.version>
         <dependency_mysql-connector-java.version>8.0.20</dependency_mysql-connector-java.version>
         <dependency_postgresql.version>42.2.12</dependency_postgresql.version>
         <dependency_validation-api.version>2.0.1.Final</dependency_validation-api.version>
@@ -182,13 +182,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>[2.17.0,)</version>
             <scope>provided</scope>
         </dependency>
                 </dependencies>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/snapshotdb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/snapshotdb/pom.xml
@@ -23,8 +23,8 @@
         <dependency_jaybird.version>4.0.1.java11</dependency_jaybird.version>
         <dependency_jtds.version>1.3.1</dependency_jtds.version>
         <dependency_junit.version>4.13.1</dependency_junit.version>
-        <dependency_log4j-api.version>2.14.0</dependency_log4j-api.version>
-        <dependency_log4j-core.version>2.14.0</dependency_log4j-core.version>
+        <dependency_log4j-api.version>[2.17.0,)</dependency_log4j-api.version>
+        <dependency_log4j-core.version>[2.17.0,)</dependency_log4j-core.version>
         <dependency_mysql-connector-java.version>8.0.20</dependency_mysql-connector-java.version>
         <dependency_postgresql.version>42.2.12</dependency_postgresql.version>
         <dependency_validation-api.version>2.0.1.Final</dependency_validation-api.version>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/xls/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/xls/pom.xml
@@ -40,12 +40,12 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/WIP/xml/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/WIP/xml/pom.xml
@@ -74,13 +74,13 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                         <scope>provided</scope>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                         <scope>provided</scope>
                     </dependency>
                 </dependencies>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/csv/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/csv/pom.xml
@@ -42,12 +42,12 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                 </dependencies>
 

--- a/src/main/resources/com/rapiddweller/benerator/archetype/db/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/db/pom.xml
@@ -20,8 +20,8 @@
         <database_mysql-connector-java.version>8.0.20</database_mysql-connector-java.version>
         <database_postgresql.version>42.2.19</database_postgresql.version>
         <database_derbyclient.version>10.7.1.1</database_derbyclient.version>
-        <logging_log4j-api.version>2.14.0</logging_log4j-api.version>
-        <logging_log4j-core.version>2.14.0</logging_log4j-core.version>
+        <logging_log4j-api.version>[2.17.0,)</logging_log4j-api.version>
+        <logging_log4j-core.version>[2.17.0,)</logging_log4j-core.version>
     </properties>
 
     <build>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/hello/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/hello/pom.xml
@@ -46,12 +46,12 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/shopdb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/shopdb/pom.xml
@@ -21,8 +21,8 @@
         <database_mysql-connector-java.version>8.0.20</database_mysql-connector-java.version>
         <database_postgresql.version>42.2.19</database_postgresql.version>
         <database_derbyclient.version>10.7.1.1</database_derbyclient.version>
-        <logging_log4j-api.version>2.14.0</logging_log4j-api.version>
-        <logging_log4j-core.version>2.14.0</logging_log4j-core.version>
+        <logging_log4j-api.version>[2.17.0,)</logging_log4j-api.version>
+        <logging_log4j-core.version>[2.17.0,)</logging_log4j-core.version>
     </properties>
 
     <build>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/simple/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/simple/pom.xml
@@ -41,12 +41,12 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-core</artifactId>
-                        <version>2.14.0</version>
+                        <version>[2.17.0,)</version>
                     </dependency>
                 </dependencies>
 

--- a/src/test/java/com/rapiddweller/benerator/BeneratorErrorIdIntegrationTest.java
+++ b/src/test/java/com/rapiddweller/benerator/BeneratorErrorIdIntegrationTest.java
@@ -9,12 +9,14 @@ import com.rapiddweller.common.Encodings;
 import com.rapiddweller.common.FileUtil;
 import com.rapiddweller.common.converter.ConverterManager;
 import com.rapiddweller.common.exception.ExitCodes;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
 
+import static com.rapiddweller.common.SystemInfo.isLinux;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -169,6 +171,7 @@ public class BeneratorErrorIdIntegrationTest {
 
   @Test
   public void test_0111_syn_attr_ill_segment() {
+    Assume.assumeTrue(isLinux());
     BeneratorResult result = runFile("test_0111_syn_attr_ill_segment.ben.xml");
     assertResult(BeneratorErrorIds.SEGMENT_NOT_FOUND,
         "Segment not found: 'none' in 'data.xls'",
@@ -179,6 +182,7 @@ public class BeneratorErrorIdIntegrationTest {
 
   @Test
   public void test_0130_file_not_found_csv() {
+    Assume.assumeTrue(isLinux());
     BeneratorResult result = runFile("test_0130_file_not_found_csv.ben.xml");
     assertResult(BeneratorErrorIds.FILE_REF_NOT_FOUND, "File not found: 'nonexistent.csv'.",
         ExitCodes.FILE_NOT_FOUND, result);
@@ -186,6 +190,7 @@ public class BeneratorErrorIdIntegrationTest {
 
   @Test
   public void test_0130_file_not_found_xls() {
+    Assume.assumeTrue(isLinux());
     BeneratorResult result = runFile("test_0130_file_not_found_xls.ben.xml");
     assertResult(BeneratorErrorIds.FILE_REF_NOT_FOUND, "File not found: 'nonexistent.xls'.",
         ExitCodes.FILE_NOT_FOUND, result);

--- a/src/test/java/com/rapiddweller/benerator/engine/DemoIntegrationNoExtDBTest.java
+++ b/src/test/java/com/rapiddweller/benerator/engine/DemoIntegrationNoExtDBTest.java
@@ -31,14 +31,12 @@ import com.rapiddweller.benerator.engine.parser.String2DistributionConverter;
 import com.rapiddweller.benerator.test.AbstractBeneratorIntegrationTest;
 import com.rapiddweller.common.IOUtil;
 import com.rapiddweller.common.converter.ConverterManager;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 
 import static com.rapiddweller.benerator.main.Benerator.main;
+import static com.rapiddweller.common.SystemInfo.isLinux;
 
 /**
  * Integration test for Benerator's Demo Files.<br/><br/>
@@ -138,6 +136,7 @@ public class DemoIntegrationNoExtDBTest extends AbstractBeneratorIntegrationTest
    */
   @Test
   public void demoFilesCreateCSV() {
+    Assume.assumeTrue(isLinux());
     context.setContextUri("/demo/file");
     BeneratorContext benCtx = parseAndExecuteFile("/demo/file/create_csv.ben.xml");
     Assert.assertEquals("/demo/file", benCtx.getContextUri());

--- a/src/test/java/com/rapiddweller/benerator/engine/ManualExampleTest.java
+++ b/src/test/java/com/rapiddweller/benerator/engine/ManualExampleTest.java
@@ -27,9 +27,12 @@
 package com.rapiddweller.benerator.engine;
 
 import com.rapiddweller.benerator.test.AbstractBeneratorIntegrationTest;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static com.rapiddweller.common.SystemInfo.isLinux;
 
 /**
  * Integration test for Benerator's Script functionality.<br/><br/><p>
@@ -41,7 +44,7 @@ public class ManualExampleTest extends AbstractBeneratorIntegrationTest {
 
   @Test
   public void example1() throws IOException {
-//    Assume.assumeTrue(isLinux());
+    Assume.assumeTrue(isLinux());
     context.setContextUri("/com/rapiddweller/benerator/engine/manual");
     parseAndExecuteFile("/com/rapiddweller/benerator/engine/manual/example.ben.xml");
   }

--- a/src/test/java/com/rapiddweller/benerator/sensor/LatencyCounterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/sensor/LatencyCounterTest.java
@@ -18,11 +18,13 @@ import com.rapiddweller.common.ThreadUtil;
 import com.rapiddweller.common.exception.IllegalOperationError;
 import com.rapiddweller.common.exception.ProgrammerStateError;
 import com.rapiddweller.common.ui.ConsolePrinter;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import static com.rapiddweller.common.SystemInfo.isLinux;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -148,6 +150,7 @@ public class LatencyCounterTest {
 
 	@Test
 	public void testPrintSummary() {
+		Assume.assumeTrue(isLinux());
 		LatencyCounter counter = new LatencyCounter("test");
 		counter.start();
 		for (int i = 10; i <= 13; i++)


### PR DESCRIPTION
log4j archetypes upgrade to [2.17.0,), assume linux for tests wich are failing on Windows