### PR TITLE
docs: add dark mode to docs page, add a placeholder to search bar

### DIFF
--- a/doc/css/extra.css
+++ b/doc/css/extra.css
@@ -8,6 +8,10 @@
   --md-primary-fg-color: #323e4f;
   --md-typeset-a-color: #00bda4;
 }
+[data-md-color-scheme="rapiddweller"]
+  [data-md-toggle="search"]:not(:checked)
+  ~ .md-header
+  .md-search__form::after {
   position: absolute;
   top: 0.3rem;
   right: 0.3rem;
@@ -17,6 +21,22 @@
   font-weight: bold;
   font-size: 0.8rem;
   border: 0.05rem solid var(--md-default-bg-color--lighter);
+  border-radius: 0.1rem;
+  content: "/";
+}
+[data-md-color-scheme="slate"]
+  [data-md-toggle="search"]:not(:checked)
+  ~ .md-header
+  .md-search__form::after {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  display: block;
+  padding: 0.1rem 0.4rem;
+  color: var(--md-default-fg-color);
+  font-weight: bold;
+  font-size: 0.8rem;
+  border: 0.05rem solid var(--md-default-fg-color--lighter);
   border-radius: 0.1rem;
   content: "/";
 }

--- a/doc/css/extra.css
+++ b/doc/css/extra.css
@@ -4,7 +4,10 @@
   --md-typeset-a-color: #00bda4;
 }
 
-[data-md-toggle="search"]:not(:checked) ~ .md-header .md-search__form::after {
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #323e4f;
+  --md-typeset-a-color: #00bda4;
+}
   position: absolute;
   top: 0.3rem;
   right: 0.3rem;

--- a/doc/css/extra.css
+++ b/doc/css/extra.css
@@ -3,3 +3,17 @@
   --md-primary-fg-color--dark: #5e949f;
   --md-typeset-a-color: #00bda4;
 }
+
+[data-md-toggle="search"]:not(:checked) ~ .md-header .md-search__form::after {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  display: block;
+  padding: 0.1rem 0.4rem;
+  color: var(--md-default-bg-color);
+  font-weight: bold;
+  font-size: 0.8rem;
+  border: 0.05rem solid var(--md-default-bg-color--lighter);
+  border-radius: 0.1rem;
+  content: "/";
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,19 @@ theme:
     text: Roboto
     code: Roboto Mono
   palette:
-    scheme: rapiddweller
-    accent: amber
+    # Palette toggle for light mode
+    - scheme: rapiddweller
+      accent: amber
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: red
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - search.suggest
     - search.highlight


### PR DESCRIPTION
## Dark mode
- Add dark mode to docs page. 
- A toggle switch to manual switch between light/dark

- Preview locally:
https://github.com/rapiddweller/rapiddweller-benerator-ce/assets/32004536/49a42fbd-7254-44be-bec3-e5beb5fa5b6f


## Search bar
- Add a "/" placeholder in the search bar to improve UX