### PR TITLE
extend script demo based on user request

### DIFF
--- a/src/demo/resources/demo/script/scriptdb.ben.xml
+++ b/src/demo/resources/demo/script/scriptdb.ben.xml
@@ -30,6 +30,12 @@
         return query;
         }
 
+        // db get entitiy count
+        function getEntityCount(entity) {
+        const count = db.countEntities(entity);
+        print('entity count for ' + entity + ' : ' + count);
+        }
+
     </execute>
 
     <execute target="db" onError="warn">
@@ -87,4 +93,8 @@
         <attribute name="PLAYLIST_TRACK" source="db" selector="{js:getQuery2(1)}" cyclic="true"/>
     </generate>
 
+    <echo>Printing entity count using JS and AbstractDatabase countEntities function</echo>
+    <execute type="js">getEntityCount('playlist');</execute>
+    <execute type="js">getEntityCount('TRACK');</execute>
+    <execute type="js">getEntityCount('PLAYLIST_TRACK');</execute>
 </setup>


### PR DESCRIPTION
I have a `<database id="myDb" />` (plus other required configs - I can access correctly to the DB).

Then inside a
```xml
<execute type="js"> block I have a
function myCount() {
  let count = myDb.countEntities("my_table");
  return count;
}
<execute/>
```

But apparently, I'm getting an error on the myDb.countEntities method. Should I not be able to perform this from the myDb "bean"