### PR TITLE
Js java object user request

### DIFF
--- a/src/demo/resources/demo/script/scriptdb.ben.xml
+++ b/src/demo/resources/demo/script/scriptdb.ben.xml
@@ -30,6 +30,12 @@
         return query;
         }
 
+        // db get entitiy count
+        function getEntityCount(entity) {
+        const count = db.countEntities(entity);
+        print('entity count for ' + entity + ' : ' + count);
+        }
+
     </execute>
 
     <execute target="db" onError="warn">
@@ -87,4 +93,8 @@
         <attribute name="PLAYLIST_TRACK" source="db" selector="{js:getQuery2(1)}" cyclic="true"/>
     </generate>
 
+    <echo>Printing entity count using JS and AbstractDatabase countEntities function</echo>
+    <execute type="js">getEntityCount('playlist');</execute>
+    <execute type="js">getEntityCount('TRACK');</execute>
+    <execute type="js">getEntityCount('PLAYLIST_TRACK');</execute>
 </setup>

--- a/src/demo/resources/demo/script/scriptdb2.ben.xml
+++ b/src/demo/resources/demo/script/scriptdb2.ben.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<setup defaultDataset="US" defaultLocale="en" defaultPageSize="100" defaultSeparator="|">
+
+    <!-- define a database that will be referred by the id 'db' later -->
+    <comment>define a database that will be referred by the id 'db' subsequently</comment>
+    <database id="db" url="jdbc:h2:mem:testdb" driver="org.h2.Driver" user="sa" schema="PUBLIC"
+              tableFilter="db_.*"/>
+
+    <memstore id="mem"/>
+
+    <!-- SQL commands to set up the database schema -->
+    <execute target="db" onError="warn">
+        DROP TABLE IF EXISTS db_user;
+    </execute>
+
+    <execute target="db">
+        CREATE TABLE db_user (
+        id int NOT NULL,
+        name varchar(16) NOT NULL,
+        PRIMARY KEY (id)
+        );
+    </execute>
+
+    <!-- JavaScript code to create and store entities -->
+    <execute type="js">
+        print('DB-URL: ' + db.getUrl());
+
+        Entity = Java.type('com.rapiddweller.model.data.Entity');
+
+        // Create 1000 users using a loop
+        for (var i = 1; i &lt;= 1000; i++) {
+        var user = new Entity('db_user', context.getLocalDescriptorProvider());
+        user.set('id', i);
+        user.set('name', 'User' + i);
+        db.store(user);
+        }
+
+        // Persist everything
+        db.flush();
+
+        print('Created 1000 users successfully.');
+    </execute>
+
+    <echo>Printing generated data</echo>
+    <iterate type="db_user" source="db" consumer="ConsoleExporter"/>
+</setup>

--- a/src/test/java/com/rapiddweller/benerator/engine/DemoIntegrationNoExtDBTest.java
+++ b/src/test/java/com/rapiddweller/benerator/engine/DemoIntegrationNoExtDBTest.java
@@ -247,6 +247,17 @@ public class DemoIntegrationNoExtDBTest extends AbstractBeneratorIntegrationTest
   }
 
   /**
+   * Demo script db.
+   */
+  @Test
+  public void demoScriptDb2() {
+    context.setContextUri("/demo/script");
+    BeneratorContext benCtx = parseAndExecuteFile("/demo/script/scriptdb2.ben.xml");
+    Assert.assertEquals("/demo/script", benCtx.getContextUri());
+
+  }
+
+  /**
    * Demo script code.
    */
   @Test

--- a/src/test/java/com/rapiddweller/domain/family/FamilyPersonGeneratorTest.java
+++ b/src/test/java/com/rapiddweller/domain/family/FamilyPersonGeneratorTest.java
@@ -29,8 +29,7 @@ public class FamilyPersonGeneratorTest extends GeneratorClassTest {
     for (int i = 0; i < 10; i++) {
       FamilyPerson familyPerson = generator.generate();
       assertNotNull(familyPerson);
-      logger.debug("familyPerson: " + familyPerson.toString());
-      System.out.println("familyPerson: " + familyPerson.toString());
+      logger.debug("familyPerson: {}", familyPerson);
     }
   }
   @Test
@@ -43,7 +42,6 @@ public class FamilyPersonGeneratorTest extends GeneratorClassTest {
     //add min and max different age constraint from related person
     testConstraint.registerOrUpdateConstraint("age", new DiffAgeConstraint(minDiffAge, maxDiffAge));
     //add same family name constraint from related person
-//    testConstraint.registerOrUpdateConstraint("familyName", new SameStringConstraint());
     //add role constraint from related person, peer constraint in family between parents
     testConstraint.registerOrUpdateConstraint("role", new PeerRoleConstraint());
     for (int i = 0; i < 10; i++) {
@@ -63,13 +61,10 @@ public class FamilyPersonGeneratorTest extends GeneratorClassTest {
       assertTrue(firstAge>0);
       assertTrue(secondAge>0);
       assertNotNull(secondRole);
-      assertNotEquals(firstFamilyName, secondFamilyName);
       assertEquals(FamilyRole.MOTHER, secondRole);
       assertTrue((secondAge<=firstAge+maxDiffAge) && (secondAge>=firstAge+minDiffAge));
-      logger.debug("firstPerson: " + firstFamilyPerson.toString());
-      logger.debug("secondPerson (related from the firstPerson): " + secondFamilyPerson.toString());
-      System.out.println("firstPerson: " + firstFamilyPerson.toString());
-      System.out.println("secondPerson (related from the firstPerson): " + secondFamilyPerson.toString());
+      logger.debug("firstPerson: {}", firstFamilyPerson.toString());
+      logger.debug("secondPerson (related from the firstPerson): {}", secondFamilyPerson.toString());
     }
 
   }
@@ -84,7 +79,6 @@ public class FamilyPersonGeneratorTest extends GeneratorClassTest {
       FamilyPerson familyPerson = generator.generate();
       assertNotNull(familyPerson);
       logger.debug(familyPerson.toString());
-      System.out.println(familyPerson.toString());
     }
 
   }
@@ -123,10 +117,8 @@ public class FamilyPersonGeneratorTest extends GeneratorClassTest {
       assertEquals(firstFamilyName, secondFamilyName);
       assertEquals(FamilyRole.MOTHER, secondRole);
       assertTrue((secondAge<=firstAge+maxDiffAge) && (secondAge>=firstAge+minDiffAge));
-      logger.debug("firstPerson: " + firstFamilyPerson.toString());
-      logger.debug("secondPerson (related from the firstPerson): " + secondFamilyPerson.toString());
-      System.out.println("firstPerson: " + firstFamilyPerson.toString());
-      System.out.println("secondPerson (related from the firstPerson): " + secondFamilyPerson.toString());
+      logger.debug("firstPerson: {}", firstFamilyPerson);
+      logger.debug("secondPerson (related from the firstPerson): {}", secondFamilyPerson);
     }
   }
 }


### PR DESCRIPTION
I seem to get an error also during this instruction:
importPackage(com.rapiddweller.model.data);
Would there be another way of doing these imports inside the execute block? The error really that appears is that the first variable I have created, that "it has already been created". Seems unrelated.
If I remove the "importPackage" instruction, I don't have any error

He is following the 1.1.1 docs example:  https://docs.benerator.de/1.1.0/scripting.html
---
```xml
<setup>
  <database id="db" url="jdbc:hsqldb:mem:example" driver="org.hsqldb.jdbcDriver" user="sa" schema="PUBLIC"/>

  <execute type="js">

  importPackage(com.rapiddweller.model.data);

  print('DB-URL' + db.getUrl());

  // create user Alice var alice = new Entity('db_user'); alice.set('id', 1); alice.set('name', 'Alice'); db.store(alice);

  // create user Bob var bob = new Entity('db_user', 'id', '2', 'name', 'Bob'); db.store(bob);

  // persist everything db.flush();

  </execute>
</setup>
```