### PR TITLE
Bump deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set ARTIFACT_ID
         run: |
           ARTIFACT_ID=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' --non-recursive exec:exec);
@@ -50,7 +50,7 @@ jobs:
           echo "echo ARTIFACT_FULLNAME=${ARTIFACT_FULLNAME} >> \$GITHUB_ENV" >> dot.env
       - run: export
       - name: Upload setupfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: setup
           path: dot.env
@@ -65,22 +65,22 @@ jobs:
       - setup
     container: maven:3.6-adoptopenjdk-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - run: mvn versions:set -DnewVersion=$ARTIFACT_VERSION
       - run: mvn $MAVEN_CLI_OPTS clean package -Dmaven.test.skip=true
       - name: Upload build artifact for assembly
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_jdk11
           path: target/*.jar
@@ -97,9 +97,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up cache for ~./m2/repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
@@ -107,7 +107,7 @@ jobs:
             maven-${{ matrix.os }}-java${{ matrix.java }}-
             maven-${{ matrix.os }}-
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -179,9 +179,9 @@ jobs:
           ORACLE_ENABLE_XDB: 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -345,9 +345,9 @@ jobs:
 #          ORACLE_ENABLE_XDB: 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -458,20 +458,20 @@ jobs:
     needs: [ test_UT_multiplatform, test_IT_jdk11, build_jdk11 ]
     container: maven:3.6-adoptopenjdk-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_jdk11
           path: target
@@ -480,7 +480,7 @@ jobs:
         run: cd target && ls
       - run: mvn $MAVEN_CLI_OPTS site:site assembly:single -Dmaven.test.skip=true
       - name: Upload dist test
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: assembly_jdk11_test
           path: |
@@ -493,15 +493,15 @@ jobs:
   E2ET_helper-scripts_jdk11:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -516,12 +516,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -540,7 +540,7 @@ jobs:
       - run: benerator $BENERATOR_HOME/demo/script/scriptfile.ben.xml
       - run: benerator $BENERATOR_HOME/demo/script/scriptdb.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_script-jdk11-log
@@ -554,12 +554,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -576,7 +576,7 @@ jobs:
         run: benerator --version
       - run: benerator $BENERATOR_HOME/demo/memstore/memstore.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_memstore-jdk11-log
@@ -590,12 +590,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -612,7 +612,7 @@ jobs:
         run: benerator --version
       - run: benerator $BENERATOR_HOME/demo/watermark/watermark.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_watermark-jdk11-log
@@ -626,12 +626,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -648,7 +648,7 @@ jobs:
         run: benerator --version
       - run: benerator $BENERATOR_HOME/demo/anon/anon.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_anon-jdk11-log
@@ -662,12 +662,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -689,7 +689,7 @@ jobs:
       - run: benerator $BENERATOR_HOME/demo/db/dbenv-old.ben.xml
       - run: benerator $BENERATOR_HOME/demo/db/dbenvconf.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_db-jdk11-log
@@ -703,12 +703,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -734,7 +734,7 @@ jobs:
       - run: benerator $BENERATOR_HOME/demo/file/import_fixed_width.ben.xml
       - run: benerator $BENERATOR_HOME/demo/file/postprocess-import.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_files-jdk11-log
@@ -748,12 +748,12 @@ jobs:
     needs: [ assembly_jdk11 ]
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -770,7 +770,7 @@ jobs:
         run: benerator --version
       - run: benerator $BENERATOR_HOME/demo/shop/shop-hsqlmem.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_hsqlmem-jdk11-log
@@ -805,12 +805,12 @@ jobs:
           --health-retries 5
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -851,7 +851,7 @@ jobs:
       - run: benerator $BENERATOR_HOME/demo/db/postgresalltypes.ben.xml
       - run: benerator $BENERATOR_HOME/demo/db/postgres-composite.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_postgresql-jdk11-log
@@ -876,12 +876,12 @@ jobs:
           MYSQL_DATABASE: "benerator"
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -909,7 +909,7 @@ jobs:
       - run: sleep 80s
       - run: benerator $BENERATOR_HOME/demo/shop/shop-mysql.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: E2ET_mysql-jdk11-log
@@ -932,12 +932,12 @@ jobs:
           SA_PASSWORD: Benerator123!
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -966,7 +966,7 @@ jobs:
       - run: sleep 60s
       - run: benerator $BENERATOR_HOME/demo/shop/shop-mssql.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: E2ET_mssql-jdk11-log
           path: benerator.log
@@ -987,12 +987,12 @@ jobs:
           ORACLE_ENABLE_XDB: 'true'
     steps:
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: assembly_jdk11_test
           path: target
@@ -1022,7 +1022,7 @@ jobs:
       - run: sleep 60s
       - run: benerator $BENERATOR_HOME/demo/shop/shop-oracle.ben.xml
       - name: Upload logfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: E2ET_oracle-jdk11-log
           path: benerator.log
@@ -1051,15 +1051,15 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
@@ -1094,20 +1094,20 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     container: maven:3.6-adoptopenjdk-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dot.env
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup
       - run: bash dot.env
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Download build_jdk11 for assembly
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_jdk11
           path: target

--- a/.github/workflows/quickcheck.yml
+++ b/.github/workflows/quickcheck.yml
@@ -20,23 +20,23 @@ jobs:
         shell: bash
     container: maven:3.9-eclipse-temurin-21
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -62,9 +62,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up cache for ~./m2/repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
@@ -72,7 +72,7 @@ jobs:
             maven-${{ matrix.os }}-java${{ matrix.java }}-
             maven-${{ matrix.os }}-
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: zulu
@@ -149,9 +149,9 @@ jobs:
           ORACLE_ENABLE_XDB: 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
The artifact actions v3 are retired and hard-fail the workflow; checkout, cache and setup-java v3 run on the deprecated Node 20. Bump all of them to v4 across ci.yml and quickcheck.yml:

- actions/checkout@v3 -> v4
- actions/cache@v3 -> v4
- actions/setup-java@v3 -> v4
- actions/upload-artifact@v3 -> v4
- actions/download-artifact@v3 -> v4

The upload-artifact v4 unique-name requirement is satisfied (every upload already uses a distinct artifact name) and all downloads are name-scoped, so no artifact-flow changes are needed.