### PR TITLE
Bump vulnerable DB drivers and libraries to patched versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,10 +132,10 @@
         <database_hsqldb.version>2.7.2</database_hsqldb.version>
         <database_icu4j.version>72.1</database_icu4j.version>
         <database_jaybird.version>5.0.1.java11</database_jaybird.version>
-        <database_mssqldb.version>12.2.0.jre11</database_mssqldb.version>
-        <database_mysql-connector-java.version>8.0.33</database_mysql-connector-java.version>
+        <database_mssqldb.version>12.8.2.jre11</database_mssqldb.version>
+        <database_mysql-connector-java.version>8.4.0</database_mysql-connector-java.version>
         <database_oracle.version>21.9.0.0</database_oracle.version>
-        <database_postgresql.version>42.5.4</database_postgresql.version>
+        <database_postgresql.version>42.7.11</database_postgresql.version>
         <database_mariadb-java-client.version>3.1.2</database_mariadb-java-client.version>
         <mongodb.version>3.12.12</mongodb.version>
         <dependency_antlr-runtime.version>3.5.3</dependency_antlr-runtime.version>
@@ -143,7 +143,7 @@
         <dependency_validation-api.version>2.0.1.Final</dependency_validation-api.version>
         <dependency_xml-apis.version>1.0.b2</dependency_xml-apis.version>
         <dependency_slf4j.version>1.7.36</dependency_slf4j.version>
-        <dependency_log4j.version>2.19.0</dependency_log4j.version>
+        <dependency_log4j.version>2.25.4</dependency_log4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scriptengine_freemarker.version>2.3.32</scriptengine_freemarker.version>
         <scriptengine_graalvm.version>22.3.1</scriptengine_graalvm.version>
@@ -378,7 +378,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.27.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/shopdb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/shopdb/pom.xml
@@ -15,10 +15,10 @@
         <database_h2.version>2.2.220</database_h2.version>
         <database_icu4j.version>67.1</database_icu4j.version>
         <database_jaybird.version>4.0.1.java11</database_jaybird.version>
-        <database_mssqldb.version>9.2.1.jre11</database_mssqldb.version>
+        <database_mssqldb.version>12.8.2.jre11</database_mssqldb.version>
         <database_oracle.version>21.1.0.0</database_oracle.version>
-        <database_mysql-connector-java.version>8.0.29</database_mysql-connector-java.version>
-        <database_postgresql.version>42.4.3</database_postgresql.version>
+        <database_mysql-connector-java.version>8.4.0</database_mysql-connector-java.version>
+        <database_postgresql.version>42.7.11</database_postgresql.version>
         <database_derbyclient.version>10.7.1.1</database_derbyclient.version>
         <logging_log4j-api.version>[2.17.0,)</logging_log4j-api.version>
         <logging_log4j-core.version>[2.17.0,)</logging_log4j-core.version>
@@ -72,8 +72,8 @@
                         <version>${database_jaybird.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
                         <version>${database_mysql-connector-java.version}</version>
                     </dependency>
                     <dependency>

--- a/src/main/resources/com/rapiddweller/benerator/archetype/simpledb_shopdb/pom.xml
+++ b/src/main/resources/com/rapiddweller/benerator/archetype/simpledb_shopdb/pom.xml
@@ -14,10 +14,10 @@
         <database_h2.version>2.2.220</database_h2.version>
         <database_icu4j.version>67.1</database_icu4j.version>
         <database_jaybird.version>4.0.1.java11</database_jaybird.version>
-        <database_mssqldb.version>9.2.1.jre11</database_mssqldb.version>
+        <database_mssqldb.version>12.8.2.jre11</database_mssqldb.version>
         <database_oracle.version>21.1.0.0</database_oracle.version>
-        <database_mysql-connector-java.version>8.0.29</database_mysql-connector-java.version>
-        <database_postgresql.version>42.4.3</database_postgresql.version>
+        <database_mysql-connector-java.version>8.4.0</database_mysql-connector-java.version>
+        <database_postgresql.version>42.7.11</database_postgresql.version>
         <database_derbyclient.version>10.7.1.1</database_derbyclient.version>
         <logging_log4j-api.version>[2.17.0,)</logging_log4j-api.version>
         <logging_log4j-core.version>[2.17.0,)</logging_log4j-core.version>
@@ -71,8 +71,8 @@
                         <version>${database_jaybird.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
                         <version>${database_mysql-connector-java.version}</version>
                     </dependency>
                     <dependency>


### PR DESCRIPTION
Addresses Dependabot alerts across the main pom and the shopdb / simpledb_shopdb archetype templates:

- org.postgresql:postgresql 42.5.4/42.4.3 -> 42.7.11 Fixes SQL injection via line comment (CVE-2024-1597, Critical) and unbounded PBKDF2 iterations SCRAM DoS (CVE-2026-42198, High).
- mysql connector 8.0.33/8.0.29 -> 8.4.0 Fixes connector takeover (CVE-2023-22102, High). In the archetypes this also moves off the retired mysql:mysql-connector-java coordinates to com.mysql:mysql-connector-j, where the fixed releases are published.
- com.microsoft.sqlserver:mssql-jdbc 12.2.0/9.2.1 -> 12.8.2.jre11 Fixes improper input validation spoofing (CVE-2025-59250, High).
- org.apache.logging.log4j:log4j-core 2.19.0 -> 2.25.4 (main pom only) Fixes silently ignored verifyHostName TLS attribute (CVE-2026-34477) and XmlLayout invalid-character handling (CVE-2026-34480).
- org.apache.commons:commons-compress 1.21 -> 1.27.1 (main pom only) Fixes DUMP infinite-loop DoS (CVE-2024-25710) and Pack200 OOM (CVE-2024-26308).

Verified: mvn compile resolves all new versions and builds cleanly; both archetype templates validate as XML.