### PR TITLE
Pin maven-gpg-plugin to 3.1.0 to fix release signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -796,6 +796,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <!-- Pinned: gpg-plugin 3.2.x enforces "best practices" that ignore
+                             the gpg.passphrase from settings.xml and break batch signing
+                             ("No secret key"). 3.1.0 is the last release compatible with the
+                             classic settings.xml passphrase plus imported-key CI setup. -->
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
The plugin version was unpinned, so CI floated it to 3.2.8. Since 3.2.0 the gpg plugin enforces "best practices" that ignore a passphrase supplied via Maven config (settings.xml gpg.passphrase) and change key/signer handling, which broke batch signing in the release pipeline with "gpg: no default secret key: No secret key" (note the log's hint to use MAVEN_GPG_PASSPHRASE / gpg-agent instead).

The signing secret was unchanged; only the floated plugin version regressed. Pin to 3.1.0, the last release compatible with the existing setup (gpg --import in CI + gpg.passphrase from settings.xml), which also makes the build reproducible.