### PR TITLE
Migrate Maven publishing from dead OSSRH to Central Portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,19 +1161,3 @@ jobs:
           asset_path: target/${{ env.ARTIFACT_FULLNAME }}-dist.tar.gz
           asset_name: ${{ env.ARTIFACT_FULLNAME }}-dist.tar.gz
           asset_content_type: application/zip
-
-  ###################### Trigger EE Pipeline ######################
-
-  trigger_ee_pipelines:
-    runs-on: ubuntu-latest
-    needs:
-      - publish_jdk11
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: trigger EE pipelines
-        if: startsWith(github.ref, 'refs/heads/development')
-        run: curl -X POST --fail -F token=$EE_TOKEN -F ref=development https://gitlab.dwellerlab.com/api/v4/projects/112/trigger/pipeline;
-        env:
-          EE_TOKEN: ${{ secrets.EE_TOKEN }}

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -6,8 +6,10 @@
             <username>${env.NEXUS_USER}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
+        <!-- Central Portal user token (central.sonatype.com). The OSSRH_USERTOKEN* secrets
+             must now hold the NEW Portal token's username/password, not the old OSSRH token. -->
         <server>
-            <id>ossrh</id>
+            <id>central</id>
             <username>${env.OSSRH_USERTOKEN}</username>
             <password>${env.OSSRH_USERTOKEN_KEY}</password>
         </server>

--- a/pom.xml
+++ b/pom.xml
@@ -817,26 +817,24 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- OSSRH (oss.sonatype.org) shut down 2025-06-30. Publishing now goes
+                         through the Central Portal. central-publishing-maven-plugin uploads on
+                         `deploy` and, with autoPublish, releases without the old staging UI.
+                         Snapshots go to the Portal snapshots repo by default (centralSnapshotsUrl),
+                         so no distributionManagement block is needed. -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
 
                 </plugins>
             </build>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
         </profile>
     </profiles>
 
@@ -853,7 +851,7 @@
         </repository>
         <repository>
             <id>snapshots-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
oss.sonatype.org (OSSRH) shut down 2025-06-30, breaking the release deploy.

- Replace nexus-staging-maven-plugin with central-publishing-maven-plugin 0.11.0 (autoPublish), drop the dead oss.sonatype.org snapshot distributionManagement (plugin defaults to the Portal snapshots repo).
- Repoint the stale snapshot resolution repo to the Portal snapshots URL.
- Rename settings.xml server id ossrh -> central for the Portal user token.
- Remove the obsolete trigger_ee_pipelines job (EE GitLab endpoint gone).

Requires the OSSRH_USERTOKEN/OSSRH_USERTOKEN_KEY secrets to hold a new Central Portal user token (old OSSRH tokens return 401).