### PR TITLE
Add state/city filtering to AddressGenerator

### DIFF
--- a/doc/domains.md
+++ b/doc/domains.md
@@ -193,6 +193,44 @@ The generated Address objects have the following data fields:
 
 * **organization** and **department**: Names of an organization and a department.
 
+### Restricting addresses to a state or city
+
+By default `AddressGenerator` draws cities from the whole country, weighted by population. To focus on
+a region, set the `stateFilter` and/or `cityFilter` properties — the city/ZIP/area-code stay
+correlated, so you get realistic local addresses without generating the whole country and filtering
+afterwards.
+
+Matching is case-insensitive: `stateFilter` accepts the state id (`FL`) or the full name (`Florida`),
+and `cityFilter` matches the city name (`Orlando`). A city name can occur in several states (there is
+an `Orlando` in both `FL` and `WV`), so combine `stateFilter` and `cityFilter` to pin one. An unknown
+state or city fails fast with a clear configuration error instead of silently generating something
+else.
+
+> The properties are named `stateFilter`/`cityFilter` (not `state`/`city`) because `state` is the
+> generator's reserved lifecycle property and would be silently ignored.
+
+```xml
+<import domains="address"/>
+
+<bean id="floridaAddresses" class="AddressGenerator">
+    <property name="dataset" value="US"/>
+    <property name="stateFilter" value="FL"/>
+</bean>
+
+<bean id="orlandoAddresses" class="AddressGenerator">
+    <property name="dataset" value="US"/>
+    <property name="stateFilter" value="FL"/>
+    <property name="cityFilter" value="Orlando"/>
+</bean>
+
+<generate type="address" count="5" consumer="ConsoleExporter">
+    <variable name="addr" generator="orlandoAddresses"/>
+    <attribute name="city" script="addr.city.name"/>
+    <attribute name="state" script="addr.city.state.id"/>
+    <attribute name="zip" script="addr.postalCode"/>
+</generate>
+```
+
 
 ## net domain
 

--- a/doc/domains.md
+++ b/doc/domains.md
@@ -206,6 +206,10 @@ an `Orlando` in both `FL` and `WV`), so combine `stateFilter` and `cityFilter` t
 state or city fails fast with a clear configuration error instead of silently generating something
 else.
 
+This works for every supported country, using that country's own state ids and names — e.g. Germany
+(`stateFilter="BY"` or `"Bayern"`) or France, whose state ids are numeric region codes
+(`stateFilter="11"` or `"Île-de-France"`).
+
 > The properties are named `stateFilter`/`cityFilter` (not `state`/`city`) because `state` is the
 > generator's reserved lifecycle property and would be silently ignored.
 

--- a/src/main/java/com/rapiddweller/domain/address/AddressGenerator.java
+++ b/src/main/java/com/rapiddweller/domain/address/AddressGenerator.java
@@ -45,6 +45,8 @@ public class AddressGenerator extends CompositeGenerator<Address> implements Non
 
   private VarLengthStringGenerator localPhoneNumberGenerator;
   private String dataset;
+  private String stateFilter;
+  private String cityFilter;
   private CityGenerator cityGenerator;
   private StreetNameGenerator streetNameGenerator;
   private CompanyNameGenerator companyNameGen;
@@ -72,6 +74,20 @@ public class AddressGenerator extends CompositeGenerator<Address> implements Non
     this.dataset = dataset;
   }
 
+  /** Restricts generation to a single state of the dataset, matched against the state id ("FL")
+   *  or full name ("Florida"), case-insensitively. Named {@code stateFilter} rather than
+   *  {@code state} because {@code state} is the generator's reserved lifecycle property. */
+  public void setStateFilter(String stateFilter) {
+    this.stateFilter = stateFilter;
+  }
+
+  /** Restricts generation to a single city, matched against the city name ("Orlando"),
+   *  case-insensitively. Combine with {@link #setStateFilter(String)} to disambiguate a city name
+   *  that occurs in several states. */
+  public void setCityFilter(String cityFilter) {
+    this.cityFilter = cityFilter;
+  }
+
   // Generator interface ---------------------------------------------------------------------------------------------
 
   @Override
@@ -80,6 +96,11 @@ public class AddressGenerator extends CompositeGenerator<Address> implements Non
     try {
       initMembers(context);
     } catch (Exception e) {
+      // A state/city filter must surface its error, not be masked by the country fallback below
+      // (which exists only to recover from missing country data for an unfiltered request).
+      if (stateFilter != null || cityFilter != null) {
+        throw e;
+      }
       logger.error("Error initializing members", e);
       Country fallBackCountry = Country.getFallback();
       if (!fallBackCountry.getIsoCode().equals(this.dataset)) {
@@ -127,7 +148,10 @@ public class AddressGenerator extends CompositeGenerator<Address> implements Non
   // private helpers -------------------------------------------------------------------------------------------------
 
   private void initMembers(GeneratorContext context) {
-    cityGenerator = registerAndInitComponent(new CityGenerator(dataset), context);
+    CityGenerator cityGen = new CityGenerator(dataset);
+    cityGen.setStateFilter(stateFilter);
+    cityGen.setCityFilter(cityFilter);
+    cityGenerator = registerAndInitComponent(cityGen, context);
     streetNameGenerator = registerAndInitComponent(new StreetNameGenerator(dataset), context);
     localPhoneNumberGenerator = registerAndInitComponent(
         BeneratorFactory.getInstance().createVarLengthStringGenerator("[0-9]", 10, 10, 1, null), context);

--- a/src/main/java/com/rapiddweller/domain/address/CityGenerator.java
+++ b/src/main/java/com/rapiddweller/domain/address/CityGenerator.java
@@ -33,6 +33,7 @@ import com.rapiddweller.benerator.dataset.AbstractDatasetGenerator;
 import com.rapiddweller.benerator.dataset.Dataset;
 import com.rapiddweller.benerator.distribution.FeatureWeight;
 import com.rapiddweller.benerator.distribution.IndividualWeight;
+import com.rapiddweller.benerator.factory.BeneratorExceptionFactory;
 import com.rapiddweller.benerator.sample.IndividualWeightSampleGenerator;
 import com.rapiddweller.benerator.util.GeneratorUtil;
 
@@ -46,12 +47,25 @@ public class CityGenerator extends AbstractDatasetGenerator<City>
 
   private static final String REGION = "/com/rapiddweller/dataset/region";
 
+  /** Optional filter: only generate cities of this state (matched against the state id or name). */
+  private String stateFilter;
+  /** Optional filter: only generate cities with this name. */
+  private String cityFilter;
+
   public CityGenerator() {
     this(null);
   }
 
   public CityGenerator(String dataset) {
     super(City.class, REGION, dataset, true);
+  }
+
+  public void setStateFilter(String state) {
+    this.stateFilter = trimToNull(state);
+  }
+
+  public void setCityFilter(String city) {
+    this.cityFilter = trimToNull(city);
   }
 
   @Override
@@ -86,11 +100,44 @@ public class CityGenerator extends AbstractDatasetGenerator<City>
     Country country = Country.getInstance(dataset.getName());
     country.checkCities();
     for (State state : country.getStates()) {
+      if (!stateMatches(state)) {
+        continue;
+      }
       for (City city : state.getCities()) {
-        generator.addValue(city);
+        if (cityMatches(city)) {
+          generator.addValue(city);
+        }
       }
     }
+    if (hasFilter() && generator.getVariety() == 0) {
+      throw BeneratorExceptionFactory.getInstance().configurationError(
+          "No cities match the address filter in dataset '" + dataset.getName() + "'"
+              + (stateFilter != null ? ", state='" + stateFilter + "'" : "")
+              + (cityFilter != null ? ", city='" + cityFilter + "'" : ""));
+    }
     return (generator.getVariety() > 0 ? generator : null);
+  }
+
+  private boolean hasFilter() {
+    return stateFilter != null || cityFilter != null;
+  }
+
+  private boolean stateMatches(State state) {
+    return stateFilter == null
+        || stateFilter.equalsIgnoreCase(state.getId())
+        || stateFilter.equalsIgnoreCase(state.getName());
+  }
+
+  private boolean cityMatches(City city) {
+    return cityFilter == null || cityFilter.equalsIgnoreCase(city.getName());
+  }
+
+  private static String trimToNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
   }
 
   @Override

--- a/src/test/java/com/rapiddweller/domain/address/AddressGeneratorIntegrationTest.java
+++ b/src/test/java/com/rapiddweller/domain/address/AddressGeneratorIntegrationTest.java
@@ -1,0 +1,36 @@
+package com.rapiddweller.domain.address;
+
+import com.rapiddweller.benerator.test.AbstractBeneratorIntegrationTest;
+import com.rapiddweller.model.data.Entity;
+import com.rapiddweller.platform.memstore.MemStore;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies the documented AddressGenerator state/city example (doc/domains.md, Address domain) works
+ * through the XML DSL -- i.e. that the {@code <property name="state"/>} / {@code city} wiring reaches
+ * the generator and produces correlated, filtered addresses. This guards the documented snippet the
+ * same way DataFakerIntegrationTest guards the faker example.
+ */
+public class AddressGeneratorIntegrationTest extends AbstractBeneratorIntegrationTest {
+
+    @Test
+    public void testDocumentedStateCityExample() {
+        MemStore mem = new MemStore("mem", context.getDataModel());
+        context.setGlobal("mem", mem);
+
+        parseAndExecuteFile("com/rapiddweller/domain/address/address_state_city.ben.xml");
+
+        Collection<Entity> rows = mem.getEntities("address");
+        assertEquals(10, rows.size());
+        for (Entity row : rows) {
+            assertEquals("FL", row.get("state"));
+            assertEquals("ORLANDO", String.valueOf(row.get("city")).toUpperCase());
+            assertNotNull("zip should be generated", row.get("zip"));
+        }
+    }
+}

--- a/src/test/java/com/rapiddweller/domain/address/AddressGeneratorIntegrationTest.java
+++ b/src/test/java/com/rapiddweller/domain/address/AddressGeneratorIntegrationTest.java
@@ -11,25 +11,38 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Verifies the documented AddressGenerator state/city example (doc/domains.md, Address domain) works
- * through the XML DSL -- i.e. that the {@code <property name="state"/>} / {@code city} wiring reaches
- * the generator and produces correlated, filtered addresses. This guards the documented snippet the
- * same way DataFakerIntegrationTest guards the faker example.
+ * Verifies the documented AddressGenerator state/city examples (doc/domains.md, Address domain) work
+ * through the XML DSL -- i.e. that the {@code <property name="stateFilter"/>} / {@code cityFilter}
+ * wiring reaches the generator and produces correlated, filtered addresses. Guards the documented
+ * snippets the same way DataFakerIntegrationTest guards the faker example, across several countries.
  */
 public class AddressGeneratorIntegrationTest extends AbstractBeneratorIntegrationTest {
 
+    private static final String PREFIX = "com/rapiddweller/domain/address";
+
+    /** US: Orlando, FL. */
     @Test
-    public void testDocumentedStateCityExample() {
+    public void testDocumentedStateCityExampleUS() {
+        runAndAssert(PREFIX + "/address_state_city.ben.xml", "FL", "ORLANDO");
+    }
+
+    /** France as a benerator model: Paris, Île-de-France (numeric state id "11"). */
+    @Test
+    public void testStateCityExampleFrance() {
+        runAndAssert(PREFIX + "/address_state_city_fr.ben.xml", "11", "PARIS");
+    }
+
+    private void runAndAssert(String benFile, String expectedState, String expectedCityUpperCase) {
         MemStore mem = new MemStore("mem", context.getDataModel());
         context.setGlobal("mem", mem);
 
-        parseAndExecuteFile("com/rapiddweller/domain/address/address_state_city.ben.xml");
+        parseAndExecuteFile(benFile);
 
         Collection<Entity> rows = mem.getEntities("address");
         assertEquals(10, rows.size());
         for (Entity row : rows) {
-            assertEquals("FL", row.get("state"));
-            assertEquals("ORLANDO", String.valueOf(row.get("city")).toUpperCase());
+            assertEquals(expectedState, row.get("state"));
+            assertEquals(expectedCityUpperCase, String.valueOf(row.get("city")).toUpperCase());
             assertNotNull("zip should be generated", row.get("zip"));
         }
     }

--- a/src/test/java/com/rapiddweller/domain/address/AddressGeneratorTest.java
+++ b/src/test/java/com/rapiddweller/domain/address/AddressGeneratorTest.java
@@ -198,6 +198,58 @@ public class AddressGeneratorTest extends GeneratorClassTest {
     generator.init(context);
   }
 
+  /** Filtering also works for Germany: state id "BY" restricts to Bavarian addresses. */
+  @Test
+  public void testGermanStateFilter() {
+    AddressGenerator generator = new AddressGenerator("DE");
+    generator.setStateFilter("BY");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      assertEquals("BY", generator.generate().getCity().getState().getId());
+    }
+  }
+
+  /** Germany, state by full name + city: Bayern / München stays correlated. */
+  @Test
+  public void testGermanStateAndCityFilter() {
+    AddressGenerator generator = new AddressGenerator("DE");
+    generator.setStateFilter("Bayern");
+    generator.setCityFilter("München");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      Address address = generator.generate();
+      assertEquals("BY", address.getCity().getState().getId());
+      assertEquals("München", address.getCity().getName());
+      assertNotNull(address.getPostalCode());
+    }
+  }
+
+  /** Filtering also works for France, whose state ids are numeric region codes ("11" = Île-de-France). */
+  @Test
+  public void testFrenchStateFilter() {
+    AddressGenerator generator = new AddressGenerator("FR");
+    generator.setStateFilter("11");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      assertEquals("11", generator.generate().getCity().getState().getId());
+    }
+  }
+
+  /** France, state by full name + city: Île-de-France / Paris stays correlated. */
+  @Test
+  public void testFrenchStateAndCityFilter() {
+    AddressGenerator generator = new AddressGenerator("FR");
+    generator.setStateFilter("Île-de-France");
+    generator.setCityFilter("Paris");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      Address address = generator.generate();
+      assertEquals("11", address.getCity().getState().getId());
+      assertEquals("Paris", address.getCity().getName());
+      assertNotNull(address.getPostalCode());
+    }
+  }
+
   // helper ----------------------------------------------------------------------------------------------------------
 
   private void check(Country country, boolean supported) {

--- a/src/test/java/com/rapiddweller/domain/address/AddressGeneratorTest.java
+++ b/src/test/java/com/rapiddweller/domain/address/AddressGeneratorTest.java
@@ -31,6 +31,7 @@ import com.rapiddweller.benerator.factory.InstanceGeneratorFactory;
 import com.rapiddweller.benerator.parser.ModelParser;
 import com.rapiddweller.benerator.test.GeneratorClassTest;
 import com.rapiddweller.benerator.util.GeneratorUtil;
+import com.rapiddweller.common.ConfigurationError;
 import com.rapiddweller.common.xml.XMLUtil;
 import com.rapiddweller.model.data.ComplexTypeDescriptor;
 import com.rapiddweller.model.data.InstanceDescriptor;
@@ -134,6 +135,67 @@ public class AddressGeneratorTest extends GeneratorClassTest {
   @Test
   public void testDEDescriptorMapping() {
     checkDescriptorMapping(Country.GERMANY);
+  }
+
+  // state / city filtering --------------------------------------------------------------------------------------------
+
+  /** state="FL" restricts generation to Florida addresses (matched by state id). */
+  @Test
+  public void testStateFilter() {
+    AddressGenerator generator = new AddressGenerator("US");
+    generator.setStateFilter("FL");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      Address address = generator.generate();
+      assertEquals("FL", address.getCity().getState().getId());
+    }
+  }
+
+  /** The state filter also accepts the full state name, case-insensitively. */
+  @Test
+  public void testStateFilterByName() {
+    AddressGenerator generator = new AddressGenerator("US");
+    generator.setStateFilter("florida");
+    generator.init(context);
+    for (int i = 0; i < 50; i++) {
+      assertEquals("FL", generator.generate().getCity().getState().getId());
+    }
+  }
+
+  /** state + city yields correlated city/state/zip for that one city (Orlando, FL). */
+  @Test
+  public void testStateAndCityFilter() {
+    AddressGenerator generator = new AddressGenerator("US");
+    generator.setStateFilter("FL");
+    generator.setCityFilter("orlando");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      Address address = generator.generate();
+      assertEquals("FL", address.getCity().getState().getId());
+      assertEquals("ORLANDO", address.getCity().getName().toUpperCase());
+      assertNotNull(address.getPostalCode());
+    }
+  }
+
+  /** A city name occurring in several states (Orlando exists in FL and WV) stays cross-state when no
+   *  state is given -- documenting that state+city is how you pin a specific one. */
+  @Test
+  public void testCityFilterIsCrossStateWithoutState() {
+    AddressGenerator generator = new AddressGenerator("US");
+    generator.setCityFilter("orlando");
+    generator.init(context);
+    for (int i = 0; i < 100; i++) {
+      Address address = generator.generate();
+      assertEquals("ORLANDO", address.getCity().getName().toUpperCase());
+    }
+  }
+
+  /** An unknown state is a configuration error, surfaced clearly rather than silently falling back. */
+  @Test(expected = ConfigurationError.class)
+  public void testUnknownStateFilterFails() {
+    AddressGenerator generator = new AddressGenerator("US");
+    generator.setStateFilter("XX");
+    generator.init(context);
   }
 
   // helper ----------------------------------------------------------------------------------------------------------

--- a/src/test/resources/com/rapiddweller/domain/address/address_state_city.ben.xml
+++ b/src/test/resources/com/rapiddweller/domain/address/address_state_city.ben.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<setup xmlns="https://www.benerator.de/schema/3.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://www.benerator.de/schema/3.0.0 https://www.benerator.de/schema/benerator-3.0.0.xsd"
+       defaultDataset="US" defaultLocale="en_US" defaultSeparator="|">
+
+    <!-- The documented AddressGenerator state/city example (doc/domains.md, Address domain).
+         Generates correlated Orlando, FL addresses. Guarded by AddressGeneratorIntegrationTest. -->
+
+    <import domains="address"/>
+
+    <bean id="orlandoAddresses" class="AddressGenerator">
+        <property name="dataset" value="US"/>
+        <property name="stateFilter" value="FL"/>
+        <property name="cityFilter" value="Orlando"/>
+    </bean>
+
+    <generate type="address" count="10" consumer="mem">
+        <variable name="addr" generator="orlandoAddresses"/>
+        <attribute name="city" script="addr.city.name"/>
+        <attribute name="state" script="addr.city.state.id"/>
+        <attribute name="zip" script="addr.postalCode"/>
+    </generate>
+</setup>

--- a/src/test/resources/com/rapiddweller/domain/address/address_state_city_fr.ben.xml
+++ b/src/test/resources/com/rapiddweller/domain/address/address_state_city_fr.ben.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<setup xmlns="https://www.benerator.de/schema/3.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://www.benerator.de/schema/3.0.0 https://www.benerator.de/schema/benerator-3.0.0.xsd"
+       defaultDataset="FR" defaultLocale="fr_FR" defaultSeparator="|">
+
+    <!-- AddressGenerator state/city filtering for France: correlated Paris, Île-de-France addresses.
+         French state ids are numeric region codes ("11" = Île-de-France). Guarded by
+         AddressGeneratorIntegrationTest. -->
+
+    <import domains="address"/>
+
+    <bean id="parisAddresses" class="AddressGenerator">
+        <property name="dataset" value="FR"/>
+        <property name="stateFilter" value="Île-de-France"/>
+        <property name="cityFilter" value="Paris"/>
+    </bean>
+
+    <generate type="address" count="10" consumer="mem">
+        <variable name="addr" generator="parisAddresses"/>
+        <attribute name="city" script="addr.city.name"/>
+        <attribute name="state" script="addr.city.state.id"/>
+        <attribute name="zip" script="addr.postalCode"/>
+    </generate>
+</setup>


### PR DESCRIPTION
Generating addresses for one state or city previously meant generating the whole country and filtering afterwards. Add stateFilter/cityFilter properties to AddressGenerator (delegated to CityGenerator) that restrict generation up front, keeping city/ZIP/area-code correlated:

  <bean id="orlandoAddresses" class="AddressGenerator">
    <property name="dataset" value="US"/>
    <property name="stateFilter" value="FL"/>
    <property name="cityFilter" value="Orlando"/>
  </bean>

Details:
- stateFilter matches the state id ("FL") or full name ("Florida"); cityFilter matches the city name; both case-insensitive and trimmed. A city name can occur in several states (Orlando in FL and WV), so combine both to pin one.
- An unknown state/city fails fast with a clear ConfigurationError. The filter error deliberately bypasses AddressGenerator's country-fallback (which only recovers from missing country data for an unfiltered request), so a typo surfaces instead of silently generating another country.
- Named stateFilter/cityFilter, not state/city: AbstractGenerator already exposes a read-only getState():GeneratorState lifecycle property, so an XML <property name="state"> would bind to that and be silently ignored.

Tests: AddressGeneratorTest covers state-by-id/name, state+city correlation, cross-state city, and the unknown-state error; AddressGeneratorIntegrationTest runs the documented .ben.xml end to end so the documented example stays correct. Documented in doc/domains.md.