### PR TITLE
Fix CI build: use buildnumber create-timestamp instead of git-queryin…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -679,17 +679,17 @@
                     <execution>
                         <phase>validate</phase>
                         <goals>
-                            <goal>create</goal>
+                            <!-- create-timestamp produces the build number purely from the clock and
+                                 never touches the SCM. The 'create' goal queries git, which fails in CI
+                                 containers with "detected dubious ownership" (the checkout is owned by a
+                                 user other than the build); a timestamp is all we need here. -->
+                            <goal>create-timestamp</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <doCheck>false</doCheck>
-                    <doUpdate>false</doUpdate>
-                    <format>{0,date,yyyy-MM-dd HH:mm:ss}</format>
-                    <items>
-                        <item>timestamp</item>
-                    </items>
+                    <timestampFormat>yyyy-MM-dd HH:mm:ss</timestampFormat>
+                    <timestampPropertyName>buildNumber</timestampPropertyName>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
…g create

The buildnumber-maven-plugin 'create' goal runs `git log` to read the SCM revision, which fails in CI containers with
"fatal: detected dubious ownership in repository" -- the checked-out workspace is owned by a different user than the one running the build, so Git 2.35.2+ refuses.

The build number was already configured as a plain timestamp (format + timestamp item), so the SCM lookup was pointless. Switch to the 'create-timestamp' goal, which formats the current time into ${buildNumber} without touching Git at all, and point timestampPropertyName at buildNumber so version.properties keeps its build_number value. Verified the property is populated and the POM still builds.