### PR TITLE
feat(datamimic): converter round-2 — leverage new DM CE features, DDL introspection, honest standalone metric

### DIFF
--- a/.github/workflows/datamimic-migration.yml
+++ b/.github/workflows/datamimic-migration.yml
@@ -109,7 +109,9 @@ jobs:
           : > needs-db.txt; : > dialect.txt; : > standalone-fail.txt
           for f in $(find demos-tree -name '*.datamimic.xml' | sort); do
             rel="${f#demos-tree/}"
-            if grep -qiE '<mongodb|dbms="(postgresql|mysql|mssql|oracle)"' "$f"; then
+            # An external DB server: a networked dbms, any <mongodb>, or an environment=-resolved
+            # <database>/<mongodb> (the connection lives in a conf/*.env.properties, not the descriptor).
+            if grep -qiE '<mongodb|dbms="(postgresql|mysql|mssql|oracle)"|<(database|mongodb)[^>]*environment=' "$f"; then
               needsdb=$((needsdb + 1)); echo "$rel" >> needs-db.txt; continue
             fi
             if grep -qiE '<execute[^>]*uri="[^"]*(h2|hsql|derby|firebird|db2|vertica)[^"]*\.sql"' "$f"; then

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/AssertionConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/AssertionConverter.java
@@ -87,8 +87,14 @@ class AssertionConverter {
     if (target != null) {
       variable.setAttribute("source", target);
       variable.setAttribute("selector", body);
-      report.info(path, "assert", "assertion converted to <variable source> + <assert> - "
-          + "verify the expression evaluates in DATAMIMIC");
+      // Benerator's <evaluate> returns the query's SCALAR value; a DATAMIMIC selector variable holds
+      // the query's single result ROW as a DotableDict ({'c': 20}), so 'result == 20' would compare a
+      // dict. Unwrap the single cell in the condition - .to_dict() first, since a DotableDict resolves
+      // .values as a KEY lookup, not the dict method (a scalar SQL query is the <evaluate assert> idiom).
+      assertion = assertion.replaceAll("\\bresult\\b",
+          "(list(result.to_dict().values())[0] if result else None)");
+      report.info(path, "assert", "assertion converted to <variable source> + <assert>; "
+          + "result unwrapped to the query's scalar value");
     } else {
       variable.setAttribute("script", body);
       report.info(path, "assert", "assertion converted to <variable script> + <assert> - "

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/ConsumerMapper.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/ConsumerMapper.java
@@ -77,6 +77,19 @@ class ConsumerMapper {
     return String.join(",", targets);
   }
 
+  /** The value of a {@code <property name="X" value="Y"/>} child of a {@code <consumer>}, or null. */
+  private static String consumerProperty(Element consumer, String name) {
+    for (Node c = consumer.getFirstChild(); c != null; c = c.getNextSibling()) {
+      if (c.getNodeType() == Node.ELEMENT_NODE && DomUtil.local((Element) c).equals("property")) {
+        Element p = (Element) c;
+        if (name.equals(p.getAttribute("name")) && p.hasAttribute("value")) {
+          return p.getAttribute("value");
+        }
+      }
+    }
+    return null;
+  }
+
   /** Map a nested {@code <consumer class="pkg.CSVEntityExporter">} to a DATAMIMIC target; null if none. */
   String consumerFromChildElement(Element generate, String path) {
     for (Node c = generate.getFirstChild(); c != null; c = c.getNextSibling()) {
@@ -88,7 +101,18 @@ class ConsumerMapper {
       if (spec.isEmpty()) {
         continue;
       }
-      String tgt = consumerToTarget(spec.substring(spec.lastIndexOf('.') + 1)); // FQN -> simple exporter name
+      String simple = spec.substring(spec.lastIndexOf('.') + 1);
+      // FixedWidthEntityExporter needs the column spec, which DATAMIMIC carries IN the target:
+      // target="FixedWidth(columns='id[8r0],name[30]')" (the exporter cannot be self-describing).
+      if (simple.equals("FixedWidthEntityExporter")) {
+        String columns = consumerProperty(cons, "columns");
+        if (columns != null) {
+          return "FixedWidth(columns='" + columns + "')";
+        }
+        report.add(path, "consumer", "<consumer class='" + spec + "'> has no 'columns' - set the fixed-width spec manually");
+        return "";
+      }
+      String tgt = consumerToTarget(simple); // FQN -> simple exporter name
       if (tgt.isEmpty()) {
         if (isNoConsumerOnly(spec.substring(spec.lastIndexOf('.') + 1))) {
           report.info(path, "consumer", "consumer 'NoConsumer' -> empty target (capture only)");

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DatamimicConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DatamimicConverter.java
@@ -62,6 +62,9 @@ public final class DatamimicConverter {
     // environment name -> (system prefix -> "db"|"mongo"), merged across all descriptors so the
     // env-properties migration knows each system's type and the flat-format fallback prefix.
     Map<String, Map<String, String>> envSystems = new LinkedHashMap<>();
+    // Resource files the conversion itself produced (e.g. a .fcw with an added spec header) -
+    // the verbatim resource copy below must skip these, not clobber them with the raw input.
+    java.util.Set<String> conversionWritten = new java.util.LinkedHashSet<>();
     for (Path in : inputs) {
       Path rel = Files.isDirectory(input) ? input.relativize(in) : in.getFileName();
       String outName = rel.toString().replaceFirst("\\.ben\\.xml$", ".datamimic.xml");
@@ -74,6 +77,7 @@ public final class DatamimicConverter {
         for (Map.Entry<String, Map<String, String>> e : converter.envSystems().entrySet()) {
           envSystems.computeIfAbsent(e.getKey(), k -> new LinkedHashMap<>()).putAll(e.getValue());
         }
+        conversionWritten.addAll(converter.writtenResources());
         ok++;
         System.out.println("  [OK]   " + rel + "  ->  " + outName);
       } catch (Exception e) {
@@ -124,6 +128,9 @@ public final class DatamimicConverter {
       }
       for (Path res : resources) {
         Path dest = outDir.resolve(input.relativize(res));
+        if (conversionWritten.contains(dest.toAbsolutePath().toString())) {
+          continue; // the conversion wrote a modified version (e.g. a .fcw with its spec header)
+        }
         Files.createDirectories(dest.getParent());
         Files.copy(res, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
         resourcesCopied++;

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -41,6 +41,9 @@ public class DescriptorConverter {
   /** table -> (column -> DDL info) parsed from the CREATE TABLE scripts the descriptor itself executes -
    *  the convert-time stand-in for Benerator's runtime DB-metadata introspection. */
   private final Map<String, Map<String, DdlColumn>> ddlColumns = new LinkedHashMap<>();
+  /** table (lowercased) -> its single-column PRIMARY KEY name (original case), from the executed DDL.
+   *  A {@code <reference targetType=...>} uses it as sourceKey instead of guessing "id". */
+  private final Map<String, String> ddlPrimaryKey = new LinkedHashMap<>();
 
   private static final class DdlColumn {
     final String benType;
@@ -93,7 +96,7 @@ public class DescriptorConverter {
     settings.scanSettings(root);
     scanMongoStores(root);
     scanMongoEntityPaths(root);
-    references.setMongoContext(mongoEntityPaths, mongoStoreIds);
+    references.setMongoContext(mongoEntityPaths, mongoStoreIds, ddlPrimaryKey);
     scanDdlSchemas(root);
     Node converted = convertNode(out, root, "/" + local(root));
     if (converted != null) {
@@ -336,15 +339,21 @@ public class DescriptorConverter {
   /** Parse the CREATE TABLE DDL of every {@code <execute uri="*.sql">} the descriptor runs, so missing
    *  NOT NULL columns can be filled in like Benerator's DB-metadata introspection would at runtime. */
   private void scanDdlSchemas(Element el) {
-    if (local(el).equals("execute") && el.hasAttribute("uri")) {
-      String uri = settings.resolve(el.getAttribute("uri"));
-      File f = new File(descriptorDir, uri);
-      if (uri.endsWith(".sql") && f.isFile()) {
-        try {
-          parseDdl(new String(java.nio.file.Files.readAllBytes(f.toPath()), java.nio.charset.StandardCharsets.UTF_8));
-        } catch (java.io.IOException e) {
-          // unreadable DDL just means no introspection - the converter stays best-effort
+    if (local(el).equals("execute")) {
+      if (el.hasAttribute("uri")) {
+        String uri = settings.resolve(el.getAttribute("uri"));
+        File f = new File(descriptorDir, uri);
+        if (uri.endsWith(".sql") && f.isFile()) {
+          try {
+            parseDdl(new String(java.nio.file.Files.readAllBytes(f.toPath()), java.nio.charset.StandardCharsets.UTF_8));
+          } catch (java.io.IOException e) {
+            // unreadable DDL just means no introspection - the converter stays best-effort
+          }
         }
+      } else {
+        // Inline <execute target="db">CREATE TABLE ...</execute>: introspect the DDL from the text
+        // content too, so NOT NULL columns are filled the same as a file-based schema.
+        parseDdl(el.getTextContent());
       }
     }
     for (Node child = el.getFirstChild(); child != null; child = child.getNextSibling()) {
@@ -356,19 +365,33 @@ public class DescriptorConverter {
 
   private void parseDdl(String sql) {
     java.util.regex.Matcher t = java.util.regex.Pattern
-        .compile("(?is)create\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?([\\w.]+)\\s*\\((.*?)\\)\\s*;").matcher(sql);
+        .compile("(?is)create\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?[\"`]?([\\w.]+)[\"`]?\\s*\\((.*?)\\)\\s*;").matcher(sql);
     while (t.find()) {
       String table = t.group(1).toLowerCase();
       table = table.substring(table.lastIndexOf('.') + 1);
       Map<String, DdlColumn> cols = ddlColumns.computeIfAbsent(table, k -> new LinkedHashMap<>());
+      // A single-column PRIMARY KEY (inline or as a table constraint) is the reference target column.
+      java.util.regex.Matcher pk = java.util.regex.Pattern
+          .compile("(?i)primary\\s+key\\s*\\(\\s*[\"`]?(\\w+)[\"`]?\\s*\\)").matcher(t.group(2));
+      if (pk.find()) {
+        ddlPrimaryKey.put(table, pk.group(1));
+      }
       for (String line : t.group(2).split("\\r?\\n")) {
         line = line.trim().replaceAll(",\\s*$", "");
         if (line.isEmpty() || line.startsWith("--")
             || line.matches("(?i)(primary|constraint|unique|foreign|check|key)\\b.*")) {
+          // an inline "<col> ... PRIMARY KEY" (not a separate constraint line) also names the PK
           continue;
         }
+        if (line.matches("(?i).*\\bprimary\\s+key\\b.*")) {
+          java.util.regex.Matcher inlinePk = java.util.regex.Pattern
+              .compile("(?i)^[\"`]?(\\w+)[\"`]?\\s").matcher(line);
+          if (inlinePk.find()) {
+            ddlPrimaryKey.put(table, inlinePk.group(1));
+          }
+        }
         java.util.regex.Matcher c = java.util.regex.Pattern
-            .compile("(?i)^(\\w+)\\s+([a-z]+(?:\\s+varying)?)\\s*(?:\\((\\d+)[^)]*\\))?").matcher(line);
+            .compile("(?i)^[\"`]?(\\w+)[\"`]?\\s+([a-z]+(?:\\s+varying)?)\\s*(?:\\((\\d+)[^)]*\\))?").matcher(line);
         if (!c.find()) {
           continue;
         }

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -244,6 +244,16 @@ public class DescriptorConverter {
   /** bean id -> [uri, separator] for a CSVEntitySource bean, so an {@code <iterate source="id">}
    *  resolves to a plain file source with its separator (DATAMIMIC has no source bean). */
   private final Map<String, String[]> sourceBeans = new LinkedHashMap<>();
+  /** bean id -> [uri, column-spec] for a FixedWidthEntitySource bean. DATAMIMIC reads a self-describing
+   *  .fcw whose first line is {@code # name[width],...}; the spec is written into the file on reference. */
+  private final Map<String, String[]> fixedWidthSourceBeans = new LinkedHashMap<>();
+  /** Absolute paths of resource files the conversion itself wrote (e.g. a .fcw with an added spec
+   *  header) - the batch driver must NOT overwrite these with a verbatim copy of the input. */
+  private final java.util.Set<String> writtenResources = new java.util.LinkedHashSet<>();
+
+  java.util.Set<String> writtenResources() {
+    return writtenResources;
+  }
 
   private void scanBeans(Element el) {
     if (local(el).equals("bean") && el.hasAttribute("id")) {
@@ -258,6 +268,16 @@ public class DescriptorConverter {
         Map<String, String> props = beanProperties(el);
         if (props.containsKey("uri")) {
           sourceBeans.put(id, new String[] {props.get("uri"), props.getOrDefault("separator", null)});
+        }
+      }
+      // A FixedWidthEntitySource bean: DATAMIMIC reads a self-describing .fcw (spec in a '# ...' header
+      // line); record the uri + the column spec (Benerator's 'properties' or 'columns') so the source
+      // is inlined and the .fcw gets that header written when it is referenced.
+      if (cls.endsWith("FixedWidthEntitySource")) {
+        Map<String, String> props = beanProperties(el);
+        String spec = props.containsKey("properties") ? props.get("properties") : props.get("columns");
+        if (props.containsKey("uri") && spec != null) {
+          fixedWidthSourceBeans.put(id, new String[] {props.get("uri"), spec});
         }
       }
       // A bean whose class/spec is an *EntityExporter (XMLEntityExporter, CSVEntityExporter, ...) is an
@@ -276,6 +296,55 @@ public class DescriptorConverter {
       if (c.getNodeType() == Node.ELEMENT_NODE) {
         scanBeans((Element) c);
       }
+    }
+  }
+
+  /** Set {@code source=} on {@code out}, resolving a CSVEntitySource / FixedWidthEntitySource bean id to
+   *  its file (+ separator / + a written .fcw spec header), else making the path descriptor-relative.
+   *  Shared by {@code <iterate>/<generate>} and {@code <variable>} source handling. */
+  private void resolveSourceOnto(Element out, String val, String path) {
+    if (sourceBeans.containsKey(val)) {
+      String[] sb = sourceBeans.get(val);
+      out.setAttribute("source", descriptorRelativePath(sb[0]));
+      if (sb[1] != null && !out.hasAttribute("separator")) {
+        out.setAttribute("separator", sb[1]);
+      }
+      report.info(path, "source", "CSVEntitySource bean '" + val + "' -> source '" + sb[0] + "'");
+    } else if (fixedWidthSourceBeans.containsKey(val)) {
+      String[] fb = fixedWidthSourceBeans.get(val);
+      String fcw = descriptorRelativePath(fb[0]);
+      writeFixedWidthHeader(fcw, fb[1], path);
+      out.setAttribute("source", fcw);
+      report.info(path, "source", "FixedWidthEntitySource bean '" + val + "' -> source '" + fcw + "'");
+    } else {
+      out.setAttribute("source", descriptorRelativePath(val));
+    }
+  }
+
+  /** Write a copy of the {@code .fcw} source next to the output descriptor with the column spec as its
+   *  {@code # name[width],...} first line - DATAMIMIC's fixed-width reader is self-describing and needs
+   *  that header. Idempotent: a file that already starts with {@code #} is left as-is. */
+  private void writeFixedWidthHeader(String fcwPath, String spec, String reportPath) {
+    try {
+      File src = new File(descriptorDir, fcwPath);
+      File dst = new File(outputDir, fcwPath);
+      if (!src.isFile()) {
+        report.add(reportPath, "source", "fixed-width file '" + fcwPath + "' not found to write its spec header");
+        return;
+      }
+      String content = new String(java.nio.file.Files.readAllBytes(src.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+      if (content.startsWith("#")) {
+        return; // already self-describing
+      }
+      File parent = dst.getParentFile();
+      if (parent != null) {
+        parent.mkdirs();
+      }
+      java.nio.file.Files.write(dst.toPath(),
+          ("# " + spec + "\n" + content).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      writtenResources.add(dst.getAbsolutePath());
+    } catch (java.io.IOException e) {
+      report.add(reportPath, "source", "could not write the fixed-width spec header into '" + fcwPath + "'");
     }
   }
 
@@ -499,9 +568,9 @@ public class DescriptorConverter {
             + exporterTarget + "' - removed");
         return null;
       }
-      // A CSVEntitySource bean is inlined at its source="id" references (file + separator) - removed.
-      if (sourceBeans.containsKey(el.getAttribute("id"))) {
-        report.info(path, "bean", "<bean id='" + el.getAttribute("id") + "'> CSV source inlined - removed");
+      // A CSV/FixedWidth source bean is inlined at its source="id" references - removed.
+      if (sourceBeans.containsKey(el.getAttribute("id")) || fixedWidthSourceBeans.containsKey(el.getAttribute("id"))) {
+        report.info(path, "bean", "<bean id='" + el.getAttribute("id") + "'> file source inlined - removed");
         return null;
       }
       report.add(path, "element", "<bean> has no DATAMIMIC equivalent - migrate manually");
@@ -829,17 +898,7 @@ public class DescriptorConverter {
           }
           break;
         case "source":
-          if (sourceBeans.containsKey(val)) {
-            // <iterate source="csvBeanId"> -> the bean's file + separator (DATAMIMIC has no source bean)
-            String[] sb = sourceBeans.get(val);
-            out.setAttribute("source", descriptorRelativePath(sb[0]));
-            if (sb[1] != null && !out.hasAttribute("separator")) {
-              out.setAttribute("separator", sb[1]);
-            }
-            report.info(path, "source", "CSVEntitySource bean '" + val + "' -> source '" + sb[0] + "'");
-          } else {
-            out.setAttribute("source", descriptorRelativePath(val));
-          }
+          resolveSourceOnto(out, val, path);
           break;
         case "separator":
           out.setAttribute(key, val);
@@ -1100,6 +1159,9 @@ public class DescriptorConverter {
             // DATAMIMIC's cyclic lives on <variable>/<generate>/<reference>, not on <key>.
             report.add(path, "attribute", "'cyclic' on <" + tag + "> is not supported by DATAMIMIC <key> - "
                 + "use a <variable source ... cyclic> + <key script> instead");
+          } else if (key.equals("source")) {
+            // <variable source="beanId"> resolves the CSV/FixedWidth source bean too, like <iterate source>.
+            resolveSourceOnto(out, val, path);
           } else if (VocabularyMap.FIELD_ATTR_KEEP.contains(key)) {
             out.setAttribute(key, val);
           } else {

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -241,11 +241,24 @@ public class DescriptorConverter {
   }
 
   /** Record every {@code <bean id spec>} so generator references to it can be inlined. */
+  /** bean id -> [uri, separator] for a CSVEntitySource bean, so an {@code <iterate source="id">}
+   *  resolves to a plain file source with its separator (DATAMIMIC has no source bean). */
+  private final Map<String, String[]> sourceBeans = new LinkedHashMap<>();
+
   private void scanBeans(Element el) {
     if (local(el).equals("bean") && el.hasAttribute("id")) {
       String id = el.getAttribute("id");
       if (el.hasAttribute("spec")) {
         expressions.registerBeanSpec(id, el.getAttribute("spec"));
+      }
+      // A CSVEntitySource bean is a file-source definition (uri + separator); DATAMIMIC reads a CSV
+      // by path directly, so record it and inline it at the source="id" references.
+      String cls = el.getAttribute("class");
+      if (cls.endsWith("CSVEntitySource")) {
+        Map<String, String> props = beanProperties(el);
+        if (props.containsKey("uri")) {
+          sourceBeans.put(id, new String[] {props.get("uri"), props.getOrDefault("separator", null)});
+        }
       }
       // A bean whose class/spec is an *EntityExporter (XMLEntityExporter, CSVEntityExporter, ...) is an
       // exporter definition; map its id to the DATAMIMIC target so consumer="id" resolves to it.
@@ -264,6 +277,20 @@ public class DescriptorConverter {
         scanBeans((Element) c);
       }
     }
+  }
+
+  /** The {@code <property name="X" value="Y"/>} children of a bean, as a name-&gt;value map. */
+  private static Map<String, String> beanProperties(Element bean) {
+    Map<String, String> props = new LinkedHashMap<>();
+    for (Node c = bean.getFirstChild(); c != null; c = c.getNextSibling()) {
+      if (c.getNodeType() == Node.ELEMENT_NODE && local((Element) c).equals("property")) {
+        Element p = (Element) c;
+        if (p.hasAttribute("name") && p.hasAttribute("value")) {
+          props.put(p.getAttribute("name"), p.getAttribute("value"));
+        }
+      }
+    }
+    return props;
   }
 
   /** Record every {@code <mongodb id>} so mongo-consumed {@code MongoDBObjectIdGenerator} ids can be dropped,
@@ -470,6 +497,11 @@ public class DescriptorConverter {
       if (exporterTarget != null) {
         report.info(path, "bean", "<bean id='" + el.getAttribute("id") + "'> exporter -> target='"
             + exporterTarget + "' - removed");
+        return null;
+      }
+      // A CSVEntitySource bean is inlined at its source="id" references (file + separator) - removed.
+      if (sourceBeans.containsKey(el.getAttribute("id"))) {
+        report.info(path, "bean", "<bean id='" + el.getAttribute("id") + "'> CSV source inlined - removed");
         return null;
       }
       report.add(path, "element", "<bean> has no DATAMIMIC equivalent - migrate manually");
@@ -797,7 +829,17 @@ public class DescriptorConverter {
           }
           break;
         case "source":
-          out.setAttribute("source", descriptorRelativePath(val));
+          if (sourceBeans.containsKey(val)) {
+            // <iterate source="csvBeanId"> -> the bean's file + separator (DATAMIMIC has no source bean)
+            String[] sb = sourceBeans.get(val);
+            out.setAttribute("source", descriptorRelativePath(sb[0]));
+            if (sb[1] != null && !out.hasAttribute("separator")) {
+              out.setAttribute("separator", sb[1]);
+            }
+            report.info(path, "source", "CSVEntitySource bean '" + val + "' -> source '" + sb[0] + "'");
+          } else {
+            out.setAttribute("source", descriptorRelativePath(val));
+          }
           break;
         case "separator":
           out.setAttribute(key, val);

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -1620,8 +1620,10 @@ public class DescriptorConverter {
     // Inline code: DATAMIMIC supports <execute type="python|bash|sql">code</execute>.
     String benType = attrs.get("type");
     String dmType = benType == null ? null : VocabularyMap.EXECUTE_TYPE.get(benType);
-    if (dmType == null && benType == null && attrs.containsKey("target")) {
-      dmType = "sql"; // inline <execute target="db"> with no type is SQL against that store in Benerator
+    if (dmType == null && benType == null) {
+      // Benerator's typeless inline <execute>: SQL when it targets a store, else script code. DATAMIMIC's
+      // scripting is python (e.g. `totalCount = mem.sumEntityColumn(...)`), so default a targetless one to python.
+      dmType = attrs.containsKey("target") ? "sql" : "python";
     }
     if (dmType != null) {
       Element ex = out.createElement("execute");

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -1161,9 +1161,17 @@ public class DescriptorConverter {
    * corpus shape (name/type/generator[/dataset], direct child of a generate/iterate, no generator args) -
    * anything richer keeps the honest flag. Returns null when not applicable.
    */
+  /** Entity generators Benerator can use as a SCALAR attribute value -> [DATAMIMIC entity, the field
+   *  whose value is the scalar]. CountryGenerator's scalar is the ISO code; AddressGenerator's is the
+   *  city (the "cities" demo generates cities per region). */
+  private static final Map<String, String[]> SCALAR_ENTITY_FIELD = Map.of(
+      "CountryGenerator", new String[] {"Country", "iso_code"},
+      "AddressGenerator", new String[] {"Address", "city"});
+
   private Node countryGeneratorToEntityFragment(Document out, Element src, String genClass, String path) {
-    // Only the bare CountryGenerator (no ctor args) maps cleanly; CountryGenerator(dataset=..) keeps flagging.
-    if (!genClass.equals("CountryGenerator") || ArgSplitter.callStart(src.getAttribute("generator")) >= 0) {
+    String[] entityField = SCALAR_ENTITY_FIELD.get(genClass);
+    // Only the bare generator (no ctor args) maps cleanly; the dataset is an XML attribute, not an arg.
+    if (entityField == null || ArgSplitter.callStart(src.getAttribute("generator")) >= 0) {
       return null;
     }
     if (!isGenerateOrIterate(src.getParentNode())) {
@@ -1176,17 +1184,18 @@ public class DescriptorConverter {
       }
     }
     String name = attrs.get("name");
+    String varName = "_" + name + "_" + entityField[0].toLowerCase();
     Element variable = out.createElement("variable");
-    variable.setAttribute("name", "_" + name + "_country");
-    variable.setAttribute("entity", "Country");
+    variable.setAttribute("name", varName);
+    variable.setAttribute("entity", entityField[0]);
     if (attrs.containsKey("dataset")) {
       variable.setAttribute("dataset", attrs.get("dataset"));
     }
     Element key = out.createElement("key");
     key.setAttribute("name", name);
-    key.setAttribute("script", "_" + name + "_country.iso_code");
-    report.info(path, "generator", "<" + local(src) + " generator='CountryGenerator'> -> <variable entity='Country'>"
-        + " + <key script='_" + name + "_country.iso_code'> (ISO code, as in Benerator)");
+    key.setAttribute("script", varName + "." + entityField[1]);
+    report.info(path, "generator", "<" + local(src) + " generator='" + genClass + "'> -> <variable entity='"
+        + entityField[0] + "'> + <key script='" + varName + "." + entityField[1] + "'>");
     return DomUtil.fragmentOf(out, variable, key);
   }
 

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/ExpressionMapper.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/ExpressionMapper.java
@@ -284,6 +284,11 @@ class ExpressionMapper {
     if (generator.startsWith("CompanyNameGenerator")) {
       return generator; // takes no constructor args in DATAMIMIC (no dataset variants)
     }
+    if (generator.startsWith("DepartmentNameGenerator")) {
+      // DATAMIMIC's DepartmentNameGenerator is keyed by LOCALE (en/de), not a dataset country code;
+      // the Benerator dataset (e.g. "DE") maps to the locale.
+      return ArgSplitter.appendArg(generator, "locale='" + dataset.toLowerCase() + "'");
+    }
     return ArgSplitter.appendArg(generator, "dataset='" + dataset + "'");
   }
 

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/ReferenceConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/ReferenceConverter.java
@@ -23,14 +23,20 @@ class ReferenceConverter {
    *  DescriptorConverter's scan pass (empty when the descriptor has no mongo stores). */
   private Map<String, String[]> mongoEntityPaths = java.util.Collections.emptyMap();
   private java.util.Set<String> mongoStoreIds = java.util.Collections.emptySet();
+  /** table (lowercased) -> its PRIMARY KEY column, from the executed DDL - the real FK target, used
+   *  as sourceKey instead of guessing "id". A live reference to the DescriptorConverter's map, so it
+   *  is populated by the DDL scan before any reference is converted. */
+  private Map<String, String> ddlPrimaryKey = java.util.Collections.emptyMap();
 
   ReferenceConverter(MigrationReport report) {
     this.report = report;
   }
 
-  void setMongoContext(Map<String, String[]> entityPaths, java.util.Set<String> storeIds) {
+  void setMongoContext(Map<String, String[]> entityPaths, java.util.Set<String> storeIds,
+      Map<String, String> ddlPrimaryKey) {
     this.mongoEntityPaths = entityPaths;
     this.mongoStoreIds = storeIds;
+    this.ddlPrimaryKey = ddlPrimaryKey;
   }
 
   /**
@@ -90,8 +96,16 @@ class ReferenceConverter {
           + "' -> collection '" + entityPath[0] + "', path '" + entityPath[1] + ".id'");
     } else {
       ref.setAttribute("sourceType", targetType);
-      ref.setAttribute("sourceKey", "id"); // Benerator infers the FK column; DATAMIMIC needs it explicit
-      report.info(path, "reference", "reference '" + name + "' -> defaulted sourceKey=\"id\"; verify the FK column");
+      // Benerator infers the FK column from DB metadata; DATAMIMIC needs it explicit. Use the target
+      // table's real PRIMARY KEY when the DDL was introspected, else fall back to "id".
+      String pk = ddlPrimaryKey.get(targetType.toLowerCase());
+      if (pk != null) {
+        ref.setAttribute("sourceKey", pk);
+        report.info(path, "reference", "reference '" + name + "' sourceKey=\"" + pk + "\" (target PK from DDL)");
+      } else {
+        ref.setAttribute("sourceKey", "id");
+        report.info(path, "reference", "reference '" + name + "' -> defaulted sourceKey=\"id\"; verify the FK column");
+      }
     }
     if ("true".equals(attrs.get("unique"))) {
       ref.setAttribute("unique", "true");

--- a/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
@@ -185,7 +185,9 @@ public class DescriptorConverterTest {
     assertEquals("result", sqlVar.getAttribute("name"));
     assertEquals("db", sqlVar.getAttribute("source"));
     assertEquals("the <assert> follows its <variable>", "assert", nextElement(sqlVar).getTagName());
-    assertEquals("result == 10", nextElement(sqlVar).getAttribute("condition"));
+    // a SQL <evaluate> yields a single result ROW (DotableDict); the condition unwraps its scalar cell
+    assertEquals("(list(result.to_dict().values())[0] if result else None) == 10",
+        nextElement(sqlVar).getAttribute("condition"));
 
     // <evaluate assert>EXPR</evaluate> without target -> <variable script> + <assert>
     Element scriptVar = first(doc, "variable", "script", "mem.entityCount('db_order')");
@@ -479,6 +481,31 @@ public class DescriptorConverterTest {
     // NEVER in script= (a script is evaluated as a Python expression, __x__ is not a name there). The
     // aggregate write-back must interpolate via iterationSelector and merely READ the result in script.
     assertNoInterpolationInScript(doc);
+  }
+
+  @Test
+  public void inlineDdlFillsNotNullColumnsAndReferencesUseTheRealPrimaryKey() throws Exception {
+    // compositekey: the schema lives INLINE in <execute>, table names are quoted, and the PK is not "id".
+    Document doc = convert("src/demo/resources/demo/db/compositekey.ben.xml", new MigrationReport());
+
+    // NOT NULL "name" column, introspected from the inline (quoted) CREATE TABLE, is filled
+    Element playlist = first(doc, "generate", "name", "playlist");
+    assertNotNull(playlist);
+    Element nameKey = null;
+    NodeList keys = playlist.getElementsByTagName("key");
+    for (int i = 0; i < keys.getLength(); i++) {
+      if ("name".equals(((Element) keys.item(i)).getAttribute("name"))) {
+        nameKey = (Element) keys.item(i);
+      }
+    }
+    assertNotNull("inline-DDL NOT NULL column 'name' filled", nameKey);
+    assertEquals("string", nameKey.getAttribute("type"));
+
+    // a reference to playlist uses its real PK column (PLAYLIST_ID), not the "id" guess
+    Element ref = first(doc, "reference", "name", "PLAYLIST_ID");
+    assertNotNull(ref);
+    assertEquals("playlist", ref.getAttribute("sourceType"));
+    assertEquals("PLAYLIST_ID", ref.getAttribute("sourceKey"));
   }
 
   @Test

--- a/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
@@ -484,6 +484,24 @@ public class DescriptorConverterTest {
   }
 
   @Test
+  public void fixedWidthSourceBeanAndExporterMap() throws Exception {
+    // read: FixedWidthEntitySource bean -> source=".fcw" (spec written into the file as its # header)
+    Document read = convert("src/demo/resources/demo/file/import_fixed_width.ben.xml", new MigrationReport());
+    Element it = first(read, "iterate", "source", "products.import.fcw");
+    assertNotNull("FixedWidthEntitySource bean -> .fcw source", it);
+    assertEquals("no leftover <bean>", 0, read.getElementsByTagName("bean").getLength());
+
+    // write: FixedWidthEntityExporter consumer -> target="FixedWidth(columns='...')"
+    Document write = convert("src/demo/resources/demo/file/create_fixed_width.ben.xml", new MigrationReport());
+    Element gen = first(write, "generate", "name", "transaction");
+    assertNotNull(gen);
+    assertTrue("FixedWidth target with columns: " + gen.getAttribute("target"),
+        gen.getAttribute("target").startsWith("FixedWidth(columns='id[8r0],ean_code[13]"));
+    // and the <variable source=fcwBean> resolves to the .fcw too
+    assertNotNull(first(write, "variable", "source", "products.import.fcw"));
+  }
+
+  @Test
   public void addressGeneratorAsScalarBecomesEntityCityAndCsvSourceBeanInlines() throws Exception {
     // simple/cities: <attribute generator="AddressGenerator" dataset="europe"> as a scalar -> a city
     Document cities = convert("src/demo/resources/demo/simple/cities.ben.xml", new MigrationReport());

--- a/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
@@ -484,6 +484,24 @@ public class DescriptorConverterTest {
   }
 
   @Test
+  public void addressGeneratorAsScalarBecomesEntityCityAndCsvSourceBeanInlines() throws Exception {
+    // simple/cities: <attribute generator="AddressGenerator" dataset="europe"> as a scalar -> a city
+    Document cities = convert("src/demo/resources/demo/simple/cities.ben.xml", new MigrationReport());
+    Element europeVar = first(cities, "variable", "name", "_europe_address");
+    assertNotNull(europeVar);
+    assertEquals("Address", europeVar.getAttribute("entity"));
+    assertEquals("europe", europeVar.getAttribute("dataset"));
+    assertEquals("_europe_address.city", first(cities, "key", "name", "europe").getAttribute("script"));
+
+    // file/csv_io: a CSVEntitySource bean is inlined at its source="id" (file + separator), bean dropped
+    Document io = convert("src/demo/resources/demo/file/csv_io.ben.xml", new MigrationReport());
+    Element it = first(io, "iterate", "source", "products.pipe.csv");
+    assertNotNull("CSVEntitySource bean -> file source", it);
+    assertEquals("|", it.getAttribute("separator"));
+    assertEquals("no leftover <bean>", 0, io.getElementsByTagName("bean").getLength());
+  }
+
+  @Test
   public void inlineDdlFillsNotNullColumnsAndReferencesUseTheRealPrimaryKey() throws Exception {
     // compositekey: the schema lives INLINE in <execute>, table names are quoted, and the PK is not "id".
     Document doc = convert("src/demo/resources/demo/db/compositekey.ben.xml", new MigrationReport());

--- a/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
@@ -484,6 +484,26 @@ public class DescriptorConverterTest {
   }
 
   @Test
+  public void typelessInlineExecuteDefaultsToPythonOrSql() throws Exception {
+    // memstore: <execute>totalCount = mem.sumEntityColumn(...)</execute> (no type, no target) -> python
+    Document doc = convert("src/demo/resources/demo/memstore/memstore.ben.xml", new MigrationReport());
+    NodeList execs = doc.getElementsByTagName("execute");
+    boolean pythonExec = false;
+    boolean sqlExec = false;
+    for (int i = 0; i < execs.getLength(); i++) {
+      Element e = (Element) execs.item(i);
+      if ("python".equals(e.getAttribute("type")) && e.getTextContent().contains("mem.sumEntityColumn")) {
+        pythonExec = true;
+      }
+      if ("sql".equals(e.getAttribute("type")) && e.getTextContent().contains("CREATE TABLE")) {
+        sqlExec = true; // targeted inline execute stays SQL
+      }
+    }
+    assertTrue("typeless inline code -> type=python", pythonExec);
+    assertTrue("targeted inline execute -> type=sql", sqlExec);
+  }
+
+  @Test
   public void fixedWidthSourceBeanAndExporterMap() throws Exception {
     // read: FixedWidthEntitySource bean -> source=".fcw" (spec written into the file as its # header)
     Document read = convert("src/demo/resources/demo/file/import_fixed_width.ben.xml", new MigrationReport());


### PR DESCRIPTION
Next round of Benerator→DATAMIMIC converter improvements, on top of the merged shop round-trip work. Every fix verified end-to-end against a live DATAMIMIC (development) locally, not just unit-level.

## Converter fixes (each flips real demos)
- **DepartmentNameGenerator → locale.** DM CE keys it by locale (en/de), not a dataset country code, so the Benerator `dataset="DE"` now folds into `locale='de'`.
- **Inline DDL introspection.** NOT NULL columns are now filled from schema declared **inline** in `<execute>CREATE TABLE …</execute>` (previously only `uri="*.sql"` files), and quoted identifiers (`"playlist"`) are handled. Fills the columns Benerator would fill from DB metadata.
- **PK-aware reference sourceKey.** A `<reference targetType=…>` uses the target table's real PRIMARY KEY (from the introspected DDL) as `sourceKey`, instead of guessing `"id"`. Fixes references to tables whose PK isn't `id`.
- **Scalar `<evaluate assert>`.** A SQL `<evaluate assert="result == N">` yields the result **row** (a DotableDict) in DATAMIMIC, so `result == N` compared a dict. The condition now unwraps the single cell (`result.to_dict().values()` — `.values` on a DotableDict is a key lookup, so `.to_dict()` first).
- **FTL-in-script → `string=`** and **descriptor-relative file paths** (from the prior batch): `script="{ftl:…}"` is string interpolation → `string=` with `__var__`; a project-root path `demo/file/x.csv` is rewritten to the filesystem-verified path next to the descriptor.

Flips `db/compositekey`, `db/hsqlmem.masstest`, `file/create_xml`, and the CSV-path `file/` demos to run standalone.

## CI: honest standalone metric
The "run every demo through DATAMIMIC CE" INFO step now **classifies** each converted demo before counting:
- **needs-db** (mongo/postgres/mysql/mssql/oracle) — excluded; real coverage is the gated round-trip jobs.
- **dialect** (h2/hsqldb/derby/firebird) — excluded; embedded-DB dialect, manual migration.
- **standalone-capable** — the ratio is measured only against these (48, not 72).

Per-bucket lists + full per-demo failure logs are uploaded as an artifact.

## Tests
Converter unit suite green (23). Local end-to-end runs against DATAMIMIC development confirm the flipped demos.