### PR TITLE
feat(datamimic): converter round-3 — DB sequences, offset, real-project idioms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
        alt="Benerator">
 </p>
 
-<p align="center"><em>Benerator: model-driven test data generation. Now in maintenance mode.</em></p>
+<p align="center"><em>Benerator: model-driven test data generation since 2006.</em></p>
 
 # rapiddweller-benerator-ce
 
@@ -14,7 +14,9 @@
 [![Java 11](https://img.shields.io/badge/Java-11-blue.svg)](#still-on-benerator-existing-users)
 [![New projects: use DATAMIMIC](https://img.shields.io/badge/new%20projects-use%20DATAMIMIC-brightgreen.svg)](https://github.com/rapiddweller/datamimic)
 
-> **Maintenance mode.** Benerator CE is maintained for bug fixes and security updates only. No new features are planned, and it stays free and open. Existing projects keep working. For new projects, **DATAMIMIC**, rapiddweller's actively developed platform, is the recommended path. This README shows you what you gain and how to move, and the team offers support with the migration.
+> **Two decades of test data engineering.** Benerator has generated test data for banks, insurers, and public-sector systems since 2006; thousands of teams started their model-driven test data work here. Benerator solved the first generation of enterprise test-data challenges. **DATAMIMIC** is what we built for today's: hybrid architectures, cloud environments, and AI-assisted workflows.
+>
+> Benerator CE stays free and open, and is maintained for bug fixes and security updates — existing projects keep working. New features land in DATAMIMIC, and this release ships a **converter** that translates Benerator projects into DATAMIMIC descriptors. This README shows what you gain and how to move; the team supports the migration.
 
 ---
 
@@ -28,7 +30,12 @@
 
 ## Why move to DATAMIMIC
 
-DATAMIMIC is rapiddweller's own platform, carrying the model-driven test-data approach forward on a modern stack. Moving gives you:
+DATAMIMIC is not "Benerator in Python." The two are different kinds of product:
+
+- **Benerator is a framework** — a generation engine you script, embed, and drive yourself. That was the right shape for its era, and it is why it lasted twenty years.
+- **DATAMIMIC is a platform** — the same model-driven core, plus the layers enterprises now ask us for: deterministic contracts with audit evidence, auto-regressive ML generation, a UI and REST API (Platform), and governed deployment on-premise or air-gapped.
+
+Concretely, moving gives you:
 
 - **Deterministic, reproducible output.** The same model and seed produce the same data, reproducible across machines, with a per-output content hash you can use as audit evidence.
 - **A familiar approach, modern foundation.** If you have worked with model-driven generation, DATAMIMIC will feel familiar: XML descriptors and first-class Python, so you can bring your own Python as generators, converters, and validators.
@@ -125,9 +132,9 @@ Benerator CE keeps working, and we keep it safe:
 
 ---
 
-## About Benerator (historical)
+## About Benerator
 
-rapiddweller Benerator is a model-driven test data generation tool designed to:
+rapiddweller Benerator is a model-driven test data generation tool, in production use since 2006, designed to:
 
 - Generate data that satisfies complex validity and distribution constraints.
 - Anonymize production data for testing and demos.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Java 11](https://img.shields.io/badge/Java-11-blue.svg)](#still-on-benerator-existing-users)
 [![New projects: use DATAMIMIC](https://img.shields.io/badge/new%20projects-use%20DATAMIMIC-brightgreen.svg)](https://github.com/rapiddweller/datamimic)
 
-> **Two decades of test data engineering.** Benerator has generated test data for banks, insurers, and public-sector systems since 2006; thousands of teams started their model-driven test data work here. Benerator solved the first generation of enterprise test-data challenges. **DATAMIMIC** is what we built for today's: hybrid architectures, cloud environments, and AI-assisted workflows.
+> **Two decades of test data engineering.** Benerator has generated model-driven test data since 2006 — more than 50,000 downloads on SourceForge alone, plus nearly twenty years of releases on Maven Central, in production at banks, insurers, and public-sector systems. Benerator solved the first generation of enterprise test-data challenges. **DATAMIMIC** is what we built for today's: hybrid architectures, cloud environments, and AI-assisted workflows.
 >
 > Benerator CE stays free and open, and is maintained for bug fixes and security updates — existing projects keep working. New features land in DATAMIMIC, and this release ships a **converter** that translates Benerator projects into DATAMIMIC descriptors. This README shows what you gain and how to move; the team supports the migration.
 

--- a/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
+++ b/src/main/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverter.java
@@ -793,6 +793,38 @@ public class DescriptorConverter {
     return script;
   }
 
+  /** Benerator {@code new DBSequenceGenerator('schema.seq'[, dbId])} -> DATAMIMIC
+   *  {@code generator="SequenceTableGenerator(sequence='schema.seq')"} plus the {@code database=}
+   *  attribute naming the store (explicit arg, else the setup's single database). True when handled. */
+  private boolean convertDbSequenceGenerator(String val, Element out, String path) {
+    String expr = val.startsWith("new ") ? val.substring(4).trim() : val.trim();
+    if (!expr.startsWith("DBSequenceGenerator")) {
+      return false;
+    }
+    List<String> args = ArgSplitter.splitTopLevel(expr.replaceAll("^DBSequenceGenerator\\(|\\)$", ""));
+    if (args.isEmpty()) {
+      return false;
+    }
+    String seq = args.get(0).trim().replaceAll("^['\"]|['\"]$", "");
+    String dbId = args.size() > 1 ? args.get(1).trim() : null;
+    if (dbId == null) {
+      // no explicit db arg: unambiguous only when the setup has exactly one relational store
+      List<String> dbIds = new java.util.ArrayList<>(storeIds);
+      dbIds.removeAll(mongoStoreIds);
+      if (dbIds.size() != 1) {
+        report.add(path, "generator", "DBSequenceGenerator('" + seq + "') names no database and the setup has "
+            + dbIds.size() + " - set database= manually");
+        return false;
+      }
+      dbId = dbIds.get(0);
+    }
+    out.setAttribute("generator", "SequenceTableGenerator(sequence='" + seq + "')");
+    out.setAttribute("database", dbId);
+    report.info(path, "generator", "DBSequenceGenerator -> SequenceTableGenerator(sequence='" + seq
+        + "') database='" + dbId + "'");
+    return true;
+  }
+
   /** A computed count {@code {a * b}} with each bare identifier wrapped in {@code int(...)} - DATAMIMIC
    *  settings from .properties are strings, and python string arithmetic throws. A single-identifier
    *  count ({@code {counts}}) already works (the runtime int()-casts the final result) and stays as-is. */
@@ -881,6 +913,7 @@ public class DescriptorConverter {
           break;
         case "name":
         case "pageSize":
+        case "offset": // skips the first N source rows - native in DATAMIMIC
           out.setAttribute(key, val);
           break;
         case "count":
@@ -1121,6 +1154,8 @@ public class DescriptorConverter {
             // Benerator composite generator on a <variable> -> DATAMIMIC entity; script field access is
             // resolved camelCase->snake_case by DATAMIMIC, so <key script="x.givenName"> passes through.
             convertCompositeGenerator(val, entityName, out, path);
+          } else if (convertDbSequenceGenerator(val, out, path)) {
+            break; // DBSequenceGenerator('seq', db) -> SequenceTableGenerator(sequence='seq') + database=
           } else {
             out.setAttribute("generator", foldDataset
                 ? ExpressionMapper.foldDatasetIntoGenerator(expressions.mapGenerator(val, path), attrs.get("dataset"))
@@ -1176,6 +1211,12 @@ public class DescriptorConverter {
           break;
         default:
           if (key.equals("cyclic") && !tag.equals("variable")) {
+            // A weighted-CSV key source samples with replacement in DATAMIMIC - it never runs out,
+            // so Benerator's cyclic flag is implicit there and simply drops.
+            if (String.valueOf(attrs.get("source")).endsWith(".wgt.csv")) {
+              report.info(path, "attribute", "'cyclic' on a .wgt.csv key source is implicit in DATAMIMIC - dropped");
+              break;
+            }
             // DATAMIMIC's cyclic lives on <variable>/<generate>/<reference>, not on <key>.
             report.add(path, "attribute", "'cyclic' on <" + tag + "> is not supported by DATAMIMIC <key> - "
                 + "use a <variable source ... cyclic> + <key script> instead");

--- a/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
+++ b/src/test/java/com/rapiddweller/benerator/main/datamimic/DescriptorConverterTest.java
@@ -599,6 +599,38 @@ public class DescriptorConverterTest {
     }
   }
 
+  @Test
+  public void realProjectIdioms_dbSequence_currentDatetime_modeIgnored_map_offset_wgtCyclic() throws Exception {
+    MigrationReport report = new MigrationReport();
+    Document doc = convert("src/test/resources/com/rapiddweller/benerator/main/datamimic/round3.ben.xml", report);
+
+    // DBSequenceGenerator('seq', db) -> SequenceTableGenerator(sequence=...) + database=
+    Element id = first(doc, "id", "name", "id");
+    assertNotNull(id);
+    assertEquals("SequenceTableGenerator(sequence='zsv.t_angebote_id_seq')", id.getAttribute("generator"));
+    assertEquals("hsms", id.getAttribute("database"));
+
+    // CurrentDateTimeGenerator -> bare DateTimeGenerator (current mode)
+    assertEquals("DateTimeGenerator", first(doc, "key", "name", "created").getAttribute("generator"));
+
+    // mode="ignored" -> field omitted entirely
+    assertTrue("mode=ignored field omitted", first(doc, "key", "name", "internal") == null);
+
+    // map="'MALE'->'m',..." folded into the script as dict.get
+    Element g = first(doc, "variable", "name", "geschlecht");
+    assertNotNull(g);
+    assertEquals("{'MALE': 'm', 'FEMALE': 'w'}.get(person.gender, person.gender)", g.getAttribute("script"));
+
+    // offset= passes through natively; cyclic on a .wgt.csv key drops silently (implicit)
+    Element it = first(doc, "iterate", "offset", "6");
+    assertNotNull("offset passes through", it);
+    Element status = first(doc, "key", "name", "status");
+    assertNotNull(status);
+    assertTrue("cyclic dropped on wgt.csv key", status.getAttribute("cyclic").isEmpty());
+    assertTrue("no manual flag for the wgt.csv cyclic", report.attention().stream()
+        .noneMatch(i -> i.detail.contains("cyclic")));
+  }
+
   private static Document convert(String input, MigrationReport report) throws Exception {
     File out = File.createTempFile("converted", ".datamimic.xml");
     out.deleteOnExit();

--- a/src/test/resources/com/rapiddweller/benerator/main/datamimic/round3.ben.xml
+++ b/src/test/resources/com/rapiddweller/benerator/main/datamimic/round3.ben.xml
@@ -1,0 +1,11 @@
+<setup xmlns="https://www.benerator.de/schema/3.0.0">
+    <database id="hsms" url="jdbc:postgresql://localhost:5432/x" driver="org.postgresql.Driver" user="u" password="p"/>
+    <generate type="t_angebote" count="5" consumer="hsms">
+        <id name="id" generator="new DBSequenceGenerator('zsv.t_angebote_id_seq', hsms)"/>
+        <attribute name="status" source="data/status.wgt.csv" cyclic="true"/>
+        <attribute name="created" generator="CurrentDateTimeGenerator"/>
+        <attribute name="internal" mode="ignored"/>
+        <variable name="geschlecht" map="'MALE'-&gt;'m','FEMALE'-&gt;'w'" script="person.gender"/>
+    </generate>
+    <iterate type="t_angebote" source="hsms" offset="6" consumer="ConsoleExporter"/>
+</setup>


### PR DESCRIPTION
Third converter round, driven by converting a real 42-descriptor production project (td-bs-basisdaten: 3 postgres schemas, memstore, JS scripts, DB sequences everywhere). Manual-attention items on that project: **874 → 60** across rounds 2+3.

## Mappings (leveraging DM CE #201/#202)
- **`new DBSequenceGenerator('schema.seq', db)` → `SequenceTableGenerator(sequence='schema.seq')` + `database='db'`** — the single biggest real-world gap (330+ occurrences in the test project). Explicit db arg wins; a setup with exactly one relational store resolves implicitly; anything else is flagged.
- **`offset=`** on iterate/generate passes through natively (DM CE #202).
- **`cyclic` on a `.wgt.csv` key source drops silently** — DATAMIMIC's weighted source samples with replacement, so the flag is implicit.
- **`CurrentDateTimeGenerator` → bare `DateTimeGenerator`** (current mode), **`mode="ignored"` → field omitted**, **`map="'A'->'b'"` → python `dict.get` folded into the script** (round-2 follow-ups, same project).

## What remains manual on the real project (60 items)
24× inline JS (`<execute type="js">` — rewrite in python), selector-only references, `<run-task>`, setup `defaultLineSeparator`/`defaultErrorHandler`. All documented manual-pass categories per the README migration guide.

## Tests
Synthetic `round3.ben.xml` corpus covers every new mapping; full converter suite green (28).