### PR TITLE
Prepare release 4.0.0 — the migration release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 <!--lint disable no-duplicate-headings-->
 
+## 4.0.0
+
+### Overview
+The migration release. Benerator 4.0.0 ships a built-in **Benerator → DATAMIMIC converter** that
+translates whole projects — descriptors, data files, SQL scripts, DbUnit datasets, and environment
+properties — into native DATAMIMIC descriptors, with a per-file report of everything that needs a
+manual decision. Benerator itself is unchanged and stays in maintenance mode; this release exists to
+give every Benerator project a tested, supported path onto rapiddweller's actively developed platform.
+
+### The converter (#501, #512, #518, #519)
+- **One command converts a whole project:**
+  `java -cp benerator.jar com.rapiddweller.benerator.main.datamimic.DatamimicConverter <project> <out> report.txt`.
+  See the README section "Migrate a project: step by step".
+- **Broad construct coverage:** generate/iterate nesting, references (including FKs resolved against
+  the target table's real primary key from the executed DDL), weighted and entity CSVs, fixed-width
+  files (read and write), DbUnit datasets (split into per-table JSON sources), dynamic FTL includes,
+  per-record SQL and MongoDB selectors, DB sequences (`DBSequenceGenerator` →
+  `SequenceTableGenerator(sequence=…)`), memstore scripting, and environment-properties migration
+  (JDBC URLs → host/port/database/dbms).
+- **Honest reporting instead of silent misconversion:** every construct without a faithful DATAMIMIC
+  equivalent is flagged in `migration-summary.md`, with recipes in `MIGRATION_PLAYBOOK.md`.
+- **Continuously verified:** CI converts the complete Benerator demo suite and runs it through the
+  real DATAMIMIC engine on every commit, including full round-trips against live PostgreSQL and
+  MongoDB — the flagship `shop` demo passes its own row-count assertions on both.
+- **Validated on production-scale input:** a real 42-descriptor project (3 schemas, DB sequences,
+  memstore, JS scripts) converts with roughly 93% of constructs handled automatically; the remainder
+  is reported for a manual pass.
+
+### Known migration limitations
+- Inline JavaScript (`<execute type="js">`, `{js:…}` scripts) must be rewritten in Python — DATAMIMIC
+  scripting is Python.
+- Columns typed only in the live database (Benerator's DB-metadata introspection) need explicit
+  `type=`/`generator=` unless the descriptor itself executes the DDL.
+- `<run-task>`, selector-only references without a `targetType`, and Benerator's
+  `ScriptedEntityExporter` (FTL-templated output) have no direct equivalent and are flagged.
+
+### Documentation
+- README repositioned: two decades of Benerator engineering, the framework-to-platform relationship
+  with DATAMIMIC, and a four-step migration guide (#519).
+
 ## 3.3.0
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,6 @@ give every Benerator project a tested, supported path onto rapiddweller's active
 - `<run-task>`, selector-only references without a `targetType`, and Benerator's
   `ScriptedEntityExporter` (FTL-templated output) have no direct equivalent and are flagged.
 
-### Documentation
-- README repositioned: two decades of Benerator engineering, the framework-to-platform relationship
-  with DATAMIMIC, and a four-step migration guide (#519).
-
 ## 3.3.0
 
 ### Overview

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,11 @@
                         <exclude>**/*DataFakerDocTopicsIntegrationTest*.class</exclude>
                     </excludes>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${surefire.jacoco.args}</argLine>
+                    <!-- add-opens: PGcustomtype defines classes via javassist, which reflects into
+                         ClassLoader.defineClass - permitted (with a warning) on JDK 11, denied on
+                         JDK 16+. The sonar job runs the tests on JDK 21, so the test JVM needs the
+                         open; the option is accepted (and harmless) on JDK 11 as well. -->
+                    <argLine>${surefire.jacoco.args} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rapiddweller</groupId>
     <artifactId>rapiddweller-benerator-ce</artifactId>
-    <version>3.3.0-jdk-11-SNAPSHOT</version>
+    <version>4.0.0-jdk-11-SNAPSHOT</version>
     <name>rapiddweller Benerator</name>
     <description>
         rapiddweller 'Benerator' is a software solution to


### PR DESCRIPTION
Release preparation per RELEASE.md: CHANGELOG section for 4.0.0 and the version bump to 4.0.0-jdk-11-SNAPSHOT.

4.0.0 ships the Benerator → DATAMIMIC converter as its headline. Rationale for the major version: the release redefines the product's role (generator + supported migration bridge), it should be visible to the long tail of users who skip patch releases, and there are no compatibility changes — Benerator behaviour is untouched.

After merge: `git tag 4.0.0 && git push --tags` on development; the pipeline publishes the artifacts and creates the GitHub release. Release-notes draft is prepared as a draft release.